### PR TITLE
fix double "no items" error when no matches

### DIFF
--- a/internal/ui/list_panels.go
+++ b/internal/ui/list_panels.go
@@ -22,7 +22,14 @@ func RenderLiveMatchesListPanel(width, height int, listModel list.Model, upcomin
 
 	// Wrap list in panel with neon styling
 	title := neonPanelTitleStyle.Width(contentWidth).Render(constants.PanelLiveMatches)
-	listView := listModel.View()
+
+	// Check if list is empty - show custom message instead of list view to avoid duplicate "no items"
+	var listView string
+	if len(listModel.Items()) == 0 {
+		listView = neonEmptyStyle.Width(contentWidth).Render(constants.EmptyNoLiveMatches)
+	} else {
+		listView = listModel.View()
+	}
 
 	// Calculate available inner height (minus borders)
 	borderHeight := 2


### PR DESCRIPTION
I found this bug when playing around.  Sometimes the left list item would show "No Items" twice (once in the top of the panel and once within the list view).   

This was part of my other PR, but I'm not happy with that and wanted to get this to you.