### PR TITLE
Add many relevant Brazilian and south-american leagues

### DIFF
--- a/docs/SUPPORTED_LEAGUES.md
+++ b/docs/SUPPORTED_LEAGUES.md
@@ -80,6 +80,7 @@ Golazo supports **60+ leagues and competitions**. Customize your selection in Se
 | 🇧🇷 | Brasileirão Série B |
 | 🇧🇷 | Copa do Brasil |
 | 🇧🇷 | Supercopa do Brasil |
+| 🇧🇷 | Campeonato Paulista |
 | 🇧🇷 | Campeonato Carioca |
 | 🇧🇷 | Campeonato Mineiro |
 | 🇧🇷 | Campeonato Gaúcho |

--- a/internal/data/settings.go
+++ b/internal/data/settings.go
@@ -87,6 +87,7 @@ var AllSupportedLeagues = map[string][]LeagueInfo{
 		{ID: 8814, Name: "Brasileirão Série B", Country: "Brazil"},
 		{ID: 9067, Name: "Copa do Brasil", Country: "Brazil"},
 		{ID: 10077, Name: "Supercopa do Brasil", Country: "Brazil"},
+		{ID: 10244, Name: "Paulista", Country: "Brazil"},
 		{ID: 10272, Name: "Carioca", Country: "Brazil"},
 		{ID: 10273, Name: "Mineiro", Country: "Brazil"},
 		{ID: 10274, Name: "Gaúcho", Country: "Brazil"},


### PR DESCRIPTION
This PR adds one south-american competition and 5 relevant brazilian ones.

- Recopa Sudamericana (SA)
- Copa do Brasil (BR - national)
- Supercopa do Brasil (BR - national)
- Paulista (BR - regional)
- Carioca (BR - regional)
- Mineiro (BR - regional)

Fixes #87 
Fixes #88 
Fixes #89