### PR TITLE
fix: address golangci-lint hints

### DIFF
--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -51,9 +51,7 @@ func fetchLiveBatchData(client *fotmob.Client, useMockData bool, batchIndex int)
 		totalLeagues := fotmob.TotalLeagues()
 		startIdx := batchIndex * LiveBatchSize
 		endIdx := startIdx + LiveBatchSize
-		if endIdx > totalLeagues {
-			endIdx = totalLeagues
-		}
+		endIdx = min(endIdx, totalLeagues)
 		isLast := endIdx >= totalLeagues
 
 		if useMockData {
@@ -376,16 +374,16 @@ func fetchGoalLinks(redditClient *reddit.Client, details *api.MatchDetails) tea.
 			}
 
 			goals = append(goals, reddit.GoalInfo{
-				MatchID:      details.ID,
-				HomeTeam:     details.HomeTeam.Name,
-				AwayTeam:     details.AwayTeam.Name,
-				ScorerName:   scorer,
-				Minute:       event.Minute,
+				MatchID:       details.ID,
+				HomeTeam:      details.HomeTeam.Name,
+				AwayTeam:      details.AwayTeam.Name,
+				ScorerName:    scorer,
+				Minute:        event.Minute,
 				DisplayMinute: event.DisplayMinute,
-				HomeScore:    homeScore,
-				AwayScore:    awayScore,
-				IsHomeTeam:   isHome,
-				MatchTime:    matchTime,
+				HomeScore:     homeScore,
+				AwayScore:     awayScore,
+				IsHomeTeam:    isHome,
+				MatchTime:     matchTime,
 			})
 		}
 
@@ -444,5 +442,3 @@ func fetchStandings(client *fotmob.Client, leagueID int, leagueName string, home
 		}
 	}
 }
-
-

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -196,7 +196,7 @@ func New(useMockData bool, debugMode bool, isDevBuild bool, newVersionAvailable 
 				f, err := os.OpenFile(logFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 				if err == nil {
 					defer f.Close()
-					f.WriteString(fmt.Sprintf("%s %s\n", time.Now().Format("2006-01-02 15:04:05"), message))
+					fmt.Fprintf(f, "%s %s\n", time.Now().Format("2006-01-02 15:04:05"), message)
 				}
 			}
 		})

--- a/internal/data/settings.go
+++ b/internal/data/settings.go
@@ -3,6 +3,7 @@ package data
 import (
 	"os"
 	"path/filepath"
+	"slices"
 
 	"gopkg.in/yaml.v3"
 )
@@ -229,12 +230,7 @@ func AllLeagueIDs() []int {
 
 // IsLeagueSelected checks if a league ID is in the selected list.
 func (s *Settings) IsLeagueSelected(leagueID int) bool {
-	for _, id := range s.SelectedLeagues {
-		if id == leagueID {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(s.SelectedLeagues, leagueID)
 }
 
 // GetAllRegions returns a list of all available regions in order.

--- a/internal/debug/fetch.go
+++ b/internal/debug/fetch.go
@@ -21,7 +21,7 @@ const (
 
 // FetchLeagueData fetches raw API response and converts to matches for a specific league, date, and tab.
 // Supports optional season parameter for historical data (e.g., "2022" for World Cup 2022).
-func FetchLeagueData(ctx context.Context, leagueID int, date time.Time, tab string, season string) (map[string]interface{}, []api.Match, error) {
+func FetchLeagueData(ctx context.Context, leagueID int, date time.Time, tab string, season string) (map[string]any, []api.Match, error) {
 	url := fmt.Sprintf("%s/leagues?id=%d&tab=%s", baseURL, leagueID, tab)
 	if season != "" {
 		url += "&season=" + season
@@ -51,7 +51,7 @@ func FetchLeagueData(ctx context.Context, leagueID int, date time.Time, tab stri
 	}
 
 	// Parse as raw JSON for display
-	var rawResponse map[string]interface{}
+	var rawResponse map[string]any
 	if err := json.Unmarshal(body, &rawResponse); err != nil {
 		return nil, nil, fmt.Errorf("parse json: %w", err)
 	}
@@ -64,7 +64,7 @@ func FetchLeagueData(ctx context.Context, leagueID int, date time.Time, tab stri
 }
 
 // FetchMatchDetails fetches raw match details and converts to MatchDetails struct.
-func FetchMatchDetails(ctx context.Context, matchID int) (map[string]interface{}, *api.MatchDetails, error) {
+func FetchMatchDetails(ctx context.Context, matchID int) (map[string]any, *api.MatchDetails, error) {
 	url := fmt.Sprintf("%s/matchDetails?matchId=%d", baseURL, matchID)
 
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
@@ -91,7 +91,7 @@ func FetchMatchDetails(ctx context.Context, matchID int) (map[string]interface{}
 	}
 
 	// Parse as raw JSON for display
-	var rawResponse map[string]interface{}
+	var rawResponse map[string]any
 	if err := json.Unmarshal(body, &rawResponse); err != nil {
 		return nil, nil, fmt.Errorf("parse json: %w", err)
 	}

--- a/internal/fotmob/stats.go
+++ b/internal/fotmob/stats.go
@@ -50,7 +50,7 @@ func (c *Client) StatsData(ctx context.Context) (*StatsData, error) {
 	successCount := 0
 
 	// Fetch 5 days of matches (today + last 4 days)
-	for i := 0; i < StatsDataDays; i++ {
+	for i := range StatsDataDays {
 		date := today.AddDate(0, 0, -i)
 		dateStr := date.Format("2006-01-02")
 		isToday := dateStr == todayStr

--- a/internal/fotmob/types.go
+++ b/internal/fotmob/types.go
@@ -147,7 +147,7 @@ type fotmobMatchDetails struct {
 		MatchFacts struct {
 			Events struct {
 				Events                []fotmobEventDetail `json:"events"`
-				PenaltyShootoutEvents interface{}         `json:"penaltyShootoutEvents,omitempty"`
+				PenaltyShootoutEvents any                 `json:"penaltyShootoutEvents,omitempty"`
 			} `json:"events"`
 			Highlights *struct {
 				URL    string `json:"url"`
@@ -187,11 +187,11 @@ type fotmobStatCategory struct {
 
 // fotmobStatItem represents a single statistic item
 type fotmobStatItem struct {
-	Key       string        `json:"key"`
-	Title     string        `json:"title"`
-	Stats     []interface{} `json:"stats"` // [homeValue, awayValue] - can be int, float, or string
-	Type      string        `json:"type,omitempty"`
-	Highlight string        `json:"highlight,omitempty"` // "home" or "away" for who's better
+	Key       string `json:"key"`
+	Title     string `json:"title"`
+	Stats     []any  `json:"stats"` // [homeValue, awayValue] - can be int, float, or string
+	Type      string `json:"type,omitempty"`
+	Highlight string `json:"highlight,omitempty"` // "home" or "away" for who's better
 }
 
 // fotmobTeamLineup represents a team's lineup (legacy format)
@@ -240,11 +240,11 @@ type fotmobPlayerInfo struct {
 
 // fotmobEventDetail represents a single event detail from FotMob
 type fotmobEventDetail struct {
-	Time    int         `json:"time"`
-	TimeStr interface{} `json:"timeStr"` // Can be int or string
-	Type    string      `json:"type"`
-	EventID int         `json:"eventId"`
-	IsHome  bool        `json:"isHome"`
+	Time    int    `json:"time"`
+	TimeStr any    `json:"timeStr"` // Can be int or string
+	Type    string `json:"type"`
+	EventID int    `json:"eventId"`
+	IsHome  bool   `json:"isHome"`
 	Player  *struct {
 		ID   int    `json:"id"`
 		Name string `json:"name"`
@@ -418,11 +418,11 @@ func (m fotmobMatchDetails) toAPIMatchDetails() *api.MatchDetails {
 
 	// Parse penalty shootout results if available
 	if m.Content.MatchFacts.Events.PenaltyShootoutEvents != nil {
-		if penaltyEvents, ok := m.Content.MatchFacts.Events.PenaltyShootoutEvents.([]interface{}); ok && len(penaltyEvents) > 0 {
+		if penaltyEvents, ok := m.Content.MatchFacts.Events.PenaltyShootoutEvents.([]any); ok && len(penaltyEvents) > 0 {
 			// Get the final penalty scores from the last event
 			lastEvent := penaltyEvents[len(penaltyEvents)-1]
-			if eventMap, ok := lastEvent.(map[string]interface{}); ok {
-				if penShootoutScore, exists := eventMap["penShootoutScore"].([]interface{}); exists && len(penShootoutScore) >= 2 {
+			if eventMap, ok := lastEvent.(map[string]any); ok {
+				if penShootoutScore, exists := eventMap["penShootoutScore"].([]any); exists && len(penShootoutScore) >= 2 {
 					if homeScoreFloat, ok := penShootoutScore[0].(float64); ok {
 						homeScore := int(homeScoreFloat)
 						if awayScoreFloat, ok := penShootoutScore[1].(float64); ok {
@@ -585,7 +585,7 @@ func (m fotmobMatchDetails) parseStatistics() []api.MatchStatistic {
 }
 
 // formatStatValue converts a stat value (can be int, float, or string) to string
-func formatStatValue(val interface{}) string {
+func formatStatValue(val any) string {
 	switch v := val.(type) {
 	case string:
 		return v

--- a/internal/reddit/client.go
+++ b/internal/reddit/client.go
@@ -261,9 +261,7 @@ func (c *Client) GoalLinks(goals []GoalInfo) map[GoalLinkKey]*GoalLink {
 
 		// Process batch
 		end := i + BatchSize
-		if end > len(uncachedGoals) {
-			end = len(uncachedGoals)
-		}
+		end = min(end, len(uncachedGoals))
 
 		for _, goal := range uncachedGoals[i:end] {
 			key := GoalLinkKey{MatchID: goal.MatchID, Minute: goal.Minute}
@@ -283,7 +281,7 @@ func (c *Client) searchForGoal(goal GoalInfo) (*GoalLink, error) {
 	maxRetries := 2               // Reduced from 3
 	baseDelay := 60 * time.Second // Increased delay between retries
 
-	for attempt := 0; attempt < maxRetries; attempt++ {
+	for attempt := range maxRetries {
 		if attempt > 0 {
 			// Exponential backoff: 30s, 60s, 120s
 			delay := time.Duration(attempt) * baseDelay

--- a/internal/ui/design/gradient_bar.go
+++ b/internal/ui/design/gradient_bar.go
@@ -96,7 +96,7 @@ func RenderGradientBar(cfg GradientBarConfig) string {
 
 	// Build home side bar with gradient (left to center)
 	var homeBar strings.Builder
-	for i := 0; i < halfWidth; i++ {
+	for i := range halfWidth {
 		ratio := float64(i) / float64(halfWidth-1)
 		midColor := startColor.BlendLab(endColor, ratio*0.5) // Blend to middle
 		hexColor := midColor.Hex()
@@ -112,7 +112,7 @@ func RenderGradientBar(cfg GradientBarConfig) string {
 
 	// Build away side bar with gradient (center to right)
 	var awayBar strings.Builder
-	for i := 0; i < halfWidth; i++ {
+	for i := range halfWidth {
 		ratio := 0.5 + (float64(i) / float64(halfWidth-1) * 0.5) // 0.5 to 1.0
 		midColor := startColor.BlendLab(endColor, ratio)
 		hexColor := midColor.Hex()
@@ -138,12 +138,10 @@ func RenderSimpleGradientBar(value float64, width int) string {
 	endColor, _ := colorful.Hex(endHex)
 
 	filledWidth := int(value * float64(width))
-	if filledWidth > width {
-		filledWidth = width
-	}
+	filledWidth = min(filledWidth, width)
 
 	var result strings.Builder
-	for i := 0; i < width; i++ {
+	for i := range width {
 		ratio := float64(i) / float64(width-1)
 		color := startColor.BlendLab(endColor, ratio)
 		hexColor := color.Hex()

--- a/internal/ui/dialog_statistics.go
+++ b/internal/ui/dialog_statistics.go
@@ -47,9 +47,7 @@ func (d *StatisticsDialog) Update(msg tea.Msg) (Dialog, DialogAction) {
 			return d, DialogActionClose{}
 		case "j", "down":
 			maxScroll := len(d.statistics) - d.maxVisible
-			if maxScroll < 0 {
-				maxScroll = 0
-			}
+			maxScroll = max(maxScroll, 0)
 			if d.scrollIndex < maxScroll {
 				d.scrollIndex++
 			}
@@ -92,9 +90,7 @@ func (d *StatisticsDialog) renderContent(width int) string {
 
 	// Calculate visible range
 	endIdx := d.scrollIndex + d.maxVisible
-	if endIdx > len(d.statistics) {
-		endIdx = len(d.statistics)
-	}
+	endIdx = min(endIdx, len(d.statistics))
 
 	// Render visible statistics
 	for i := d.scrollIndex; i < endIdx; i++ {

--- a/internal/ui/list_delegate.go
+++ b/internal/ui/list_delegate.go
@@ -203,7 +203,7 @@ func (d LeagueListDelegate) HighlightMatches(text, filterValue string) string {
 		matchIndex := -1
 		for i := lastIndex; i <= len(textRunes)-len(filterRunes); i++ {
 			match := true
-			for j := 0; j < len(filterRunes); j++ {
+			for j := range len(filterRunes) {
 				if !strings.EqualFold(string(textRunes[i+j]), string(filterRunes[j])) {
 					match = false
 					break

--- a/internal/ui/logo/logo.go
+++ b/internal/ui/logo/logo.go
@@ -65,7 +65,7 @@ func Render(version string, compact bool, o Opts) string {
 
 	// Apply gradient to the title
 	b := new(strings.Builder)
-	for _, line := range strings.Split(golazo, "\n") {
+	for line := range strings.SplitSeq(golazo, "\n") {
 		if line != "" {
 			b.WriteString(applyLineGradient(line, o.GradientStartHex, o.GradientEndHex))
 		}

--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -218,9 +218,7 @@ func RenderSettingsView(width, height int, state *SettingsState, bannerType cons
 
 	listWidth := settingsBoxWidth
 	listHeight := height - titleHeight - tabsHeight - infoHeight - helpHeight - extraPadding
-	if listHeight < 5 {
-		listHeight = 5
-	}
+	listHeight = max(listHeight, 5)
 
 	// Update list dimensions
 	state.List.SetSize(listWidth, listHeight)


### PR DESCRIPTION
Fixes linter warnings and applies recommended modern Go patterns.  
No logic changes.