### PR TITLE
fix[match-details]: resolve nil results for match list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Silent Error Swallowing** - Settings save, notification, and Reddit client init errors are now logged instead of discarded
 - **Live Score Sync** - Fixed left panel score falling out of sync with the right panel between 5-minute list refreshes
 - **Match Details Broken** - Fixed match data returning empty after FotMob removed their JSON API endpoints
+- **Live View Upcoming Matches** - Fixed upcoming matches not showing unless stats view was visited first
 
 ## [0.22.0] - 2026-02-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - **Silent Error Swallowing** - Settings save, notification, and Reddit client init errors are now logged instead of discarded
 - **Live Score Sync** - Fixed left panel score falling out of sync with the right panel between 5-minute list refreshes
+- **Match Details Broken** - Fixed match data returning empty after FotMob removed their JSON API endpoints
 
 ## [0.22.0] - 2026-02-20
 

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -61,7 +61,9 @@ func fetchLiveBatchData(parentCtx context.Context, client *fotmob.Client, useMoc
 		// Fetch all leagues in this batch concurrently
 		var wg sync.WaitGroup
 		var mu sync.Mutex
-		allMatches := make([]api.Match, 0, (endIdx-startIdx)*5)
+		allLive := make([]api.Match, 0, (endIdx-startIdx)*5)
+		allUpcoming := make([]api.Match, 0, (endIdx-startIdx)*5)
+		today := time.Now()
 
 		for i := startIdx; i < endIdx; i++ {
 			wg.Add(1)
@@ -72,13 +74,20 @@ func fetchLiveBatchData(parentCtx context.Context, client *fotmob.Client, useMoc
 				ctx, cancel := context.WithTimeout(parentCtx, 10*time.Second)
 				defer cancel()
 
-				matches, err := client.LiveMatchesForLeague(ctx, leagueID)
+				// Fetch all fixtures (live + upcoming) instead of just live
+				matches, err := client.MatchesForLeagueAndDate(ctx, leagueID, today, "fixtures")
 				if err != nil || len(matches) == 0 {
 					return
 				}
 
 				mu.Lock()
-				allMatches = append(allMatches, matches...)
+				for _, m := range matches {
+					if m.Status == api.MatchStatusLive {
+						allLive = append(allLive, m)
+					} else if m.Status == api.MatchStatusNotStarted {
+						allUpcoming = append(allUpcoming, m)
+					}
+				}
 				mu.Unlock()
 			}(i)
 		}
@@ -88,13 +97,16 @@ func fetchLiveBatchData(parentCtx context.Context, client *fotmob.Client, useMoc
 		return liveBatchDataMsg{
 			batchIndex: batchIndex,
 			isLast:     isLast,
-			matches:    allMatches,
+			matches:    allLive,
+			upcoming:   allUpcoming,
 		}
 	}
 }
 
 // scheduleLiveRefresh schedules the next live matches refresh after 5 minutes.
 // This is used to keep the live matches list current while the user is in the view.
+// Fetches both live and upcoming matches so the upcoming section stays current
+// as matches transition from upcoming to live.
 func scheduleLiveRefresh(client *fotmob.Client, useMockData bool) tea.Cmd {
 	return tea.Tick(LiveRefreshInterval, func(t time.Time) tea.Msg {
 		if useMockData {
@@ -105,16 +117,27 @@ func scheduleLiveRefresh(client *fotmob.Client, useMockData bool) tea.Cmd {
 			return liveRefreshMsg{matches: nil}
 		}
 
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
-		// Force refresh to bypass cache
-		matches, err := client.LiveMatchesForceRefresh(ctx)
+		// Force refresh to bypass cache - fetch all fixtures to get both live and upcoming
+		today := time.Now()
+		client.Cache().ClearLive()
+		allMatches, err := client.MatchesByDateWithTabs(ctx, today, []string{"fixtures"})
 		if err != nil {
 			return liveRefreshMsg{matches: nil}
 		}
 
-		return liveRefreshMsg{matches: matches}
+		var live, upcoming []api.Match
+		for _, m := range allMatches {
+			if m.Status == api.MatchStatusLive {
+				live = append(live, m)
+			} else if m.Status == api.MatchStatusNotStarted {
+				upcoming = append(upcoming, m)
+			}
+		}
+
+		return liveRefreshMsg{matches: live, upcoming: upcoming}
 	})
 }
 

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -81,6 +81,8 @@ func (m model) handleMainViewKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			totalLeagues := fotmob.TotalLeagues()
 			m.liveTotalBatches = (totalLeagues + LiveBatchSize - 1) / LiveBatchSize // Ceiling division
 			m.liveMatchesBuffer = nil                                               // Clear buffer
+			m.liveUpcomingBuffer = nil                                              // Clear upcoming buffer
+			m.liveUpcomingMatches = nil                                             // Clear upcoming display
 			m.liveMatchesList.SetItems([]list.Item{})
 			cmds = append(cmds, ui.SpinnerTick())
 			// Start fetching batch 0 (4 leagues in parallel) - results shown when batch completes

--- a/internal/app/messages.go
+++ b/internal/app/messages.go
@@ -24,7 +24,8 @@ type liveMatchesMsg struct {
 
 // liveRefreshMsg is sent when live matches are refreshed (periodic 5-min timer).
 type liveRefreshMsg struct {
-	matches []api.Match
+	matches  []api.Match
+	upcoming []api.Match
 }
 
 // liveBatchDataMsg contains live matches for a batch of leagues (parallel loading).
@@ -33,6 +34,7 @@ type liveBatchDataMsg struct {
 	batchIndex int         // Which batch (0, 1, 2, ...)
 	isLast     bool        // true if this is the last batch
 	matches    []api.Match // live matches from all leagues in this batch
+	upcoming   []api.Match // upcoming (not started) matches from this batch
 	err        error
 }
 

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -221,7 +221,7 @@ func New(useMockData bool, debugMode bool, isDevBuild bool, newVersionAvailable 
 		isDevBuild:             isDevBuild,
 		newVersionAvailable:    newVersionAvailable,
 		appVersion:             appVersion,
-		fotmobClient:           fotmob.NewClient(),
+		fotmobClient:           newFotmobClient(logger),
 		parser:                 fotmob.NewLiveUpdateParser(),
 		redditClient:           redditClient,
 		goalLinks:              make(map[reddit.GoalLinkKey]*reddit.GoalLink),
@@ -243,6 +243,13 @@ func New(useMockData bool, debugMode bool, isDevBuild bool, newVersionAvailable 
 		dialogOverlay:          ui.NewDialogOverlay(), // Initialize dialog overlay
 		animatedLogo:           animatedLogo,          // Initialize animated logo
 	}
+}
+
+// newFotmobClient creates a FotMob client and wires the debug logger.
+func newFotmobClient(logger *slog.Logger) *fotmob.Client {
+	c := fotmob.NewClient()
+	c.SetLogger(logger)
+	return c
 }
 
 // initLogger creates a structured logger. When debugMode is true, logs to ~/.golazo/golazo_debug.log.

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -63,9 +63,10 @@ type model struct {
 	statsTotalDays  int // Total days to load (5)
 
 	// Progressive loading state (live view) - batch-based for parallel fetching
-	liveBatchesLoaded int         // Number of batches loaded so far
-	liveTotalBatches  int         // Total batches to load
-	liveMatchesBuffer []api.Match // Buffer to accumulate live matches during progressive load
+	liveBatchesLoaded   int         // Number of batches loaded so far
+	liveTotalBatches    int         // Total batches to load
+	liveMatchesBuffer   []api.Match // Buffer to accumulate live matches during progressive load
+	liveUpcomingBuffer  []api.Match // Buffer to accumulate upcoming matches during progressive load
 
 	// UI components
 	spinner          spinner.Model

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -627,6 +627,13 @@ func (m model) handleLiveRefresh(msg liveRefreshMsg) (tea.Model, tea.Cmd) {
 	// Schedule the next refresh
 	cmds = append(cmds, scheduleLiveRefresh(m.fotmobClient, m.useMockData))
 
+	// Update upcoming matches
+	upcomingDisplay := make([]ui.MatchDisplay, 0, len(msg.upcoming))
+	for _, match := range msg.upcoming {
+		upcomingDisplay = append(upcomingDisplay, ui.MatchDisplay{Match: match})
+	}
+	m.liveUpcomingMatches = upcomingDisplay
+
 	if len(msg.matches) == 0 {
 		// No live matches - clear list but keep view
 		m.matches = nil
@@ -678,6 +685,16 @@ func (m model) handleLiveBatchData(msg liveBatchDataMsg) (tea.Model, tea.Cmd) {
 	if len(msg.matches) > 0 {
 		m.liveMatchesBuffer = append(m.liveMatchesBuffer, msg.matches...)
 		m.lastError = ""
+	}
+
+	// Accumulate upcoming matches from this batch
+	if len(msg.upcoming) > 0 {
+		m.liveUpcomingBuffer = append(m.liveUpcomingBuffer, msg.upcoming...)
+		upcomingDisplay := make([]ui.MatchDisplay, 0, len(m.liveUpcomingBuffer))
+		for _, match := range m.liveUpcomingBuffer {
+			upcomingDisplay = append(upcomingDisplay, ui.MatchDisplay{Match: match})
+		}
+		m.liveUpcomingMatches = upcomingDisplay
 	}
 
 	// Track progress

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -728,7 +728,7 @@ func (m model) handleLiveBatchData(msg liveBatchDataMsg) (tea.Model, tea.Cmd) {
 		m.liveViewLoading = false
 		m.loading = false
 
-		if len(m.liveMatchesBuffer) == 0 {
+		if len(m.liveMatchesBuffer) == 0 && len(m.liveUpcomingBuffer) == 0 {
 			m.lastError = constants.ErrorLoadFailed
 		}
 

--- a/internal/fotmob/client.go
+++ b/internal/fotmob/client.go
@@ -150,106 +150,131 @@ func (c *Client) MatchesByDateWithTabs(ctx context.Context, date time.Time, tabs
 	// Track skipped leagues for logging/debugging
 	var skippedFromCache int
 
-	// Query specified tabs
+	// Determine which statuses to include based on requested tabs
+	wantFinished := false
+	wantLive := false
+	wantNotStarted := false
 	for _, tab := range tabs {
-		for _, leagueID := range activeLeagues {
-			// Check empty cache before spawning goroutine (for "results" tab only)
-			// Skip leagues known to have no matches on this date
-			if tab == "results" && c.emptyCache != nil && c.emptyCache.IsEmpty(requestDateStr, leagueID) {
-				skippedFromCache++
-				continue
+		switch tab {
+		case "results":
+			wantFinished = true
+		case "fixtures":
+			wantLive = true
+			wantNotStarted = true
+		}
+	}
+
+	// Query each league by fetching its page (the old /api/leagues JSON endpoint is gone)
+	for _, leagueID := range activeLeagues {
+		// Check empty cache before spawning goroutine
+		if wantFinished && !wantLive && !wantNotStarted && c.emptyCache != nil && c.emptyCache.IsEmpty(requestDateStr, leagueID) {
+			skippedFromCache++
+			continue
+		}
+
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			c.maxConcurrent <- struct{}{}        // acquire semaphore
+			defer func() { <-c.maxConcurrent }() // release semaphore
+
+			// Apply rate limiting (minimal delay for concurrent requests)
+			c.rateLimiter.Wait()
+
+			// Fetch league page and extract data from __NEXT_DATA__
+			pageProps, err := fetchLeagueFromPage(ctx, c.httpClient, id)
+			if err != nil {
+				// Skip this league on error - best effort aggregation
+				return
 			}
 
-			wg.Add(1)
-			go func(id int, tabName string) {
-				defer wg.Done()
-				c.maxConcurrent <- struct{}{}        // acquire semaphore
-				defer func() { <-c.maxConcurrent }() // release semaphore
+			var leagueResponse struct {
+				Details struct {
+					ID          int    `json:"id"`
+					Name        string `json:"name"`
+					Country     string `json:"country"`
+					CountryCode string `json:"countryCode,omitempty"`
+				} `json:"details"`
+				Fixtures struct {
+					AllMatches []fotmobMatch `json:"allMatches"`
+				} `json:"fixtures"`
+			}
 
-				// Apply rate limiting (minimal delay for concurrent requests)
-				c.rateLimiter.Wait()
+			if err := json.Unmarshal(pageProps, &leagueResponse); err != nil {
+				// Skip this league on parse error - best effort aggregation
+				return
+			}
 
-				url := fmt.Sprintf("%s/leagues?id=%d&tab=%s", c.baseURL, id, tabName)
+			// Filter matches for the requested date, status, and add league info
+			// The page returns ALL season matches, so we filter client-side
+			leagueMatches := make([]api.Match, 0, 10)
+			for _, m := range leagueResponse.Fixtures.AllMatches {
+				if m.Status.UTCTime == "" {
+					continue
+				}
 
-				req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+				// Parse the UTC time - FotMob sometimes uses .000Z format
+				var matchTime time.Time
+				matchTime, err = time.Parse(time.RFC3339, m.Status.UTCTime)
 				if err != nil {
-					// Skip this league on error - best effort aggregation
-					return
+					matchTime, err = time.Parse("2006-01-02T15:04:05.000Z", m.Status.UTCTime)
 				}
-
-				req.Header.Set("User-Agent", "Mozilla/5.0")
-
-				resp, err := c.httpClient.Do(req)
 				if err != nil {
-					// Skip this league on request error - best effort aggregation
-					return
-				}
-				defer func() { _ = resp.Body.Close() }()
-
-				var leagueResponse struct {
-					Details struct {
-						ID          int    `json:"id"`
-						Name        string `json:"name"`
-						Country     string `json:"country"`
-						CountryCode string `json:"countryCode,omitempty"`
-					} `json:"details"`
-					Fixtures struct {
-						AllMatches []fotmobMatch `json:"allMatches"`
-					} `json:"fixtures"`
+					continue
 				}
 
-				if err := json.NewDecoder(resp.Body).Decode(&leagueResponse); err != nil {
-					// Skip this league on parse error - best effort aggregation
-					return
+				// Compare dates in UTC to avoid timezone issues
+				matchDateStr := matchTime.UTC().Format("2006-01-02")
+				if matchDateStr != requestDateStr {
+					continue
 				}
 
-				// Filter matches for the requested date and add league info
-				// Note: Matches are sorted chronologically, so we need to check all matches
-				leagueMatches := make([]api.Match, 0, len(leagueResponse.Fixtures.AllMatches))
-				for _, m := range leagueResponse.Fixtures.AllMatches {
-					// Check if match is on the requested date
-					if m.Status.UTCTime != "" {
-						// Parse the UTC time - FotMob sometimes uses .000Z format
-						var matchTime time.Time
-						var err error
-						matchTime, err = time.Parse(time.RFC3339, m.Status.UTCTime)
-						if err != nil {
-							// Try alternative format with milliseconds (.000Z)
-							matchTime, err = time.Parse("2006-01-02T15:04:05.000Z", m.Status.UTCTime)
-						}
-						if err == nil {
-							// Compare dates in UTC to avoid timezone issues
-							matchDateStr := matchTime.UTC().Format("2006-01-02")
-							if matchDateStr == requestDateStr {
-								// Set league info from the response details
-								if m.League.ID == 0 {
-									m.League = league{
-										ID:          leagueResponse.Details.ID,
-										Name:        leagueResponse.Details.Name,
-										Country:     leagueResponse.Details.Country,
-										CountryCode: leagueResponse.Details.CountryCode,
-									}
-								}
-								apiMatch := m.toAPIMatch()
-								c.StorePageURL(apiMatch.ID, apiMatch.PageURL)
-								leagueMatches = append(leagueMatches, apiMatch)
-							}
-						}
+				// Filter by status based on requested tabs
+				isFinished := m.Status.Finished != nil && *m.Status.Finished
+				isStarted := m.Status.Started != nil && *m.Status.Started
+				isCancelled := m.Status.Cancelled != nil && *m.Status.Cancelled
+
+				if isCancelled {
+					continue
+				}
+
+				include := false
+				if isFinished && wantFinished {
+					include = true
+				} else if isStarted && !isFinished && wantLive {
+					include = true
+				} else if !isStarted && !isFinished && wantNotStarted {
+					include = true
+				}
+
+				if !include {
+					continue
+				}
+
+				// Set league info from the response details
+				if m.League.ID == 0 {
+					m.League = league{
+						ID:          leagueResponse.Details.ID,
+						Name:        leagueResponse.Details.Name,
+						Country:     leagueResponse.Details.Country,
+						CountryCode: leagueResponse.Details.CountryCode,
 					}
 				}
+				apiMatch := m.toAPIMatch()
+				c.StorePageURL(apiMatch.ID, apiMatch.PageURL)
+				leagueMatches = append(leagueMatches, apiMatch)
+			}
 
-				// Mark league+date as empty if no matches found (for results tab only)
-				// This will be persisted to avoid future API calls
-				if len(leagueMatches) == 0 && tabName == "results" && c.emptyCache != nil {
-					c.emptyCache.MarkEmpty(requestDateStr, id)
-				}
+			// Mark league+date as empty if no finished matches found (results-only query)
+			if len(leagueMatches) == 0 && wantFinished && !wantLive && c.emptyCache != nil {
+				c.emptyCache.MarkEmpty(requestDateStr, id)
+			}
 
-				// Append to shared slice with mutex protection
-				mu.Lock()
-				allMatches = append(allMatches, leagueMatches...)
-				mu.Unlock()
-			}(leagueID, tab)
-		}
+			// Append to shared slice with mutex protection
+			mu.Lock()
+			allMatches = append(allMatches, leagueMatches...)
+			mu.Unlock()
+		}(leagueID)
 	}
 
 	// Variable is used below (prevents unused variable error)
@@ -274,20 +299,11 @@ func (c *Client) MatchesForLeagueAndDate(ctx context.Context, leagueID int, date
 	// Apply rate limiting
 	c.rateLimiter.Wait()
 
-	url := fmt.Sprintf("%s/leagues?id=%d&tab=%s", c.baseURL, leagueID, tab)
-
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	// Fetch league page and extract data from __NEXT_DATA__
+	pageProps, err := fetchLeagueFromPage(ctx, c.httpClient, leagueID)
 	if err != nil {
-		return nil, fmt.Errorf("create request for league %d: %w", leagueID, err)
+		return nil, fmt.Errorf("fetch league %d page: %w", leagueID, err)
 	}
-
-	req.Header.Set("User-Agent", "Mozilla/5.0")
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("fetch league %d: %w", leagueID, err)
-	}
-	defer func() { _ = resp.Body.Close() }()
 
 	var leagueResponse struct {
 		Details struct {
@@ -301,37 +317,70 @@ func (c *Client) MatchesForLeagueAndDate(ctx context.Context, leagueID int, date
 		} `json:"fixtures"`
 	}
 
-	if err := json.NewDecoder(resp.Body).Decode(&leagueResponse); err != nil {
+	if err := json.Unmarshal(pageProps, &leagueResponse); err != nil {
 		return nil, fmt.Errorf("decode league %d response: %w", leagueID, err)
 	}
 
-	// Filter matches for the requested date
+	// Determine which statuses to include based on tab
+	wantFinished := tab == "results"
+	wantLive := tab == "fixtures"
+	wantNotStarted := tab == "fixtures"
+
+	// Filter matches for the requested date and status
 	matches := make([]api.Match, 0, 10)
 	for _, m := range leagueResponse.Fixtures.AllMatches {
-		if m.Status.UTCTime != "" {
-			var matchTime time.Time
-			var parseErr error
-			matchTime, parseErr = time.Parse(time.RFC3339, m.Status.UTCTime)
-			if parseErr != nil {
-				matchTime, parseErr = time.Parse("2006-01-02T15:04:05.000Z", m.Status.UTCTime)
-			}
-			if parseErr == nil {
-				matchDateStr := matchTime.UTC().Format("2006-01-02")
-				if matchDateStr == requestDateStr {
-					if m.League.ID == 0 {
-						m.League = league{
-							ID:          leagueResponse.Details.ID,
-							Name:        leagueResponse.Details.Name,
-							Country:     leagueResponse.Details.Country,
-							CountryCode: leagueResponse.Details.CountryCode,
-						}
-					}
-					apiMatch := m.toAPIMatch()
-				c.StorePageURL(apiMatch.ID, apiMatch.PageURL)
-				matches = append(matches, apiMatch)
-				}
+		if m.Status.UTCTime == "" {
+			continue
+		}
+
+		var matchTime time.Time
+		var parseErr error
+		matchTime, parseErr = time.Parse(time.RFC3339, m.Status.UTCTime)
+		if parseErr != nil {
+			matchTime, parseErr = time.Parse("2006-01-02T15:04:05.000Z", m.Status.UTCTime)
+		}
+		if parseErr != nil {
+			continue
+		}
+
+		matchDateStr := matchTime.UTC().Format("2006-01-02")
+		if matchDateStr != requestDateStr {
+			continue
+		}
+
+		// Filter by status
+		isFinished := m.Status.Finished != nil && *m.Status.Finished
+		isStarted := m.Status.Started != nil && *m.Status.Started
+		isCancelled := m.Status.Cancelled != nil && *m.Status.Cancelled
+
+		if isCancelled {
+			continue
+		}
+
+		include := false
+		if isFinished && wantFinished {
+			include = true
+		} else if isStarted && !isFinished && wantLive {
+			include = true
+		} else if !isStarted && !isFinished && wantNotStarted {
+			include = true
+		}
+
+		if !include {
+			continue
+		}
+
+		if m.League.ID == 0 {
+			m.League = league{
+				ID:          leagueResponse.Details.ID,
+				Name:        leagueResponse.Details.Name,
+				Country:     leagueResponse.Details.Country,
+				CountryCode: leagueResponse.Details.CountryCode,
 			}
 		}
+		apiMatch := m.toAPIMatch()
+		c.StorePageURL(apiMatch.ID, apiMatch.PageURL)
+		matches = append(matches, apiMatch)
 	}
 
 	return matches, nil
@@ -552,23 +601,10 @@ func (c *Client) fetchLeagueTable(ctx context.Context, leagueID int) ([]api.Leag
 	// Apply rate limiting
 	c.rateLimiter.Wait()
 
-	url := fmt.Sprintf("%s/leagues?id=%d", c.baseURL, leagueID)
-
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	// Fetch league page and extract data from __NEXT_DATA__
+	pageProps, err := fetchLeagueFromPage(ctx, c.httpClient, leagueID)
 	if err != nil {
-		return nil, fmt.Errorf("create request for league %d table: %w", leagueID, err)
-	}
-
-	req.Header.Set("User-Agent", "Mozilla/5.0")
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("fetch league table for league %d: %w", leagueID, err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code %d for league %d table", resp.StatusCode, leagueID)
+		return nil, fmt.Errorf("fetch league %d table page: %w", leagueID, err)
 	}
 
 	// FotMob returns table data in several formats:
@@ -585,21 +621,17 @@ func (c *Client) fetchLeagueTable(ctx context.Context, leagueID int) ([]api.Leag
 					All []fotmobTableRow `json:"all"`
 				} `json:"table"`
 				// Multi-table format: knockout competitions and multi-season leagues
-				// Examples:
-				//   - Champions League: single table with all teams
-				//   - Liga MX: Clausura + Apertura tables
-				//   - Liga Profesional: Apertura Group A + Group B tables
 				Tables []struct {
 					Table struct {
 						All []fotmobTableRow `json:"all"`
 					} `json:"table"`
-					LeagueName string `json:"leagueName"` // e.g., "Clausura", "Apertura - Group A"
+					LeagueName string `json:"leagueName"`
 				} `json:"tables"`
 			} `json:"data"`
 		} `json:"table"`
 	}
 
-	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+	if err := json.Unmarshal(pageProps, &response); err != nil {
 		return nil, fmt.Errorf("decode league table response for league %d: %w", leagueID, err)
 	}
 
@@ -607,12 +639,9 @@ func (c *Client) fetchLeagueTable(ctx context.Context, leagueID int) ([]api.Leag
 	var tableData []fotmobTableRow
 	if len(response.Table) > 0 {
 		data := response.Table[0].Data
-		// Try regular league format first (single table with all teams)
 		if len(data.Table.All) > 0 {
 			tableData = data.Table.All
 		} else if len(data.Tables) > 0 {
-			// Multi-table format: use first sub-table (current/most relevant season)
-			// This covers both knockout competitions and multi-season leagues
 			for _, subTable := range data.Tables {
 				if len(subTable.Table.All) > 0 {
 					tableData = subTable.Table.All

--- a/internal/fotmob/client.go
+++ b/internal/fotmob/client.go
@@ -404,8 +404,8 @@ func (c *Client) MatchesForLeagueAndDate(ctx context.Context, leagueID int, date
 // Results are cached to avoid redundant API calls.
 //
 // Uses page-based fetching (match page HTML with __NEXT_DATA__) as the primary
-// method, since the /api/matchDetails endpoint now requires Cloudflare Turnstile
-// verification. Falls back to the direct API endpoint if page fetching fails.
+// method. FotMob removed their /api/matchDetails JSON endpoint (returns 404).
+// Falls back to the direct API endpoint if page fetching fails (unlikely to work).
 func (c *Client) MatchDetails(ctx context.Context, matchID int) (*api.MatchDetails, error) {
 	// Check cache first
 	if cached := c.cache.Details(matchID); cached != nil {
@@ -436,8 +436,8 @@ func (c *Client) MatchDetails(ctx context.Context, matchID int) (*api.MatchDetai
 }
 
 // matchDetailsFromAPI fetches match details from the /api/matchDetails endpoint.
-// This is the original fetching method, kept as a fallback in case the endpoint
-// becomes accessible again or for specific match IDs without a page URL.
+// This endpoint currently returns 404 (FotMob removed it). Kept as a last-resort
+// fallback in case the endpoint is restored or for match IDs without a page URL.
 func (c *Client) matchDetailsFromAPI(ctx context.Context, matchID int) (*api.MatchDetails, error) {
 	url := fmt.Sprintf("%s/matchDetails?matchId=%d", c.baseURL, matchID)
 

--- a/internal/fotmob/client.go
+++ b/internal/fotmob/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strings"
 	"sync"
@@ -39,6 +40,7 @@ type Client struct {
 	pageURLs      map[int]string     // Match ID -> page slug mapping for page-based fetching
 	pageURLsMu    sync.RWMutex
 	maxConcurrent chan struct{} // Semaphore to limit concurrent API requests
+	logger        *slog.Logger // Optional debug logger (no-op if nil)
 }
 
 // NewClient creates a new FotMob API client with default configuration.
@@ -68,6 +70,18 @@ func NewClient() *Client {
 		emptyCache:    emptyCache,
 		pageURLs:      make(map[int]string, 50),
 		maxConcurrent: make(chan struct{}, 10),
+	}
+}
+
+// SetLogger sets the debug logger for the client.
+// When set, the client logs diagnostic info about fetch paths and errors.
+func (c *Client) SetLogger(logger *slog.Logger) {
+	c.logger = logger
+}
+
+func (c *Client) debugLog(msg string, args ...any) {
+	if c.logger != nil {
+		c.logger.Debug(msg, args...)
 	}
 }
 
@@ -395,6 +409,7 @@ func (c *Client) MatchesForLeagueAndDate(ctx context.Context, leagueID int, date
 func (c *Client) MatchDetails(ctx context.Context, matchID int) (*api.MatchDetails, error) {
 	// Check cache first
 	if cached := c.cache.Details(matchID); cached != nil {
+		c.debugLog("MatchDetails: cache hit", "matchID", matchID)
 		return cached, nil
 	}
 
@@ -402,16 +417,21 @@ func (c *Client) MatchDetails(ctx context.Context, matchID int) (*api.MatchDetai
 	c.rateLimiter.Wait()
 
 	// Try page-based fetching first (primary method)
-	if pageSlug := c.getPageURL(matchID); pageSlug != "" {
+	pageSlug := c.getPageURL(matchID)
+	if pageSlug != "" {
+		c.debugLog("MatchDetails: fetching from page", "matchID", matchID, "pageSlug", pageSlug)
 		details, err := fetchMatchDetailsFromPage(ctx, c.httpClient, pageSlug)
 		if err == nil && details != nil {
 			c.cache.SetDetails(matchID, details)
+			c.debugLog("MatchDetails: page fetch success", "matchID", matchID, "events", len(details.Events))
 			return details, nil
 		}
-		// Page fetch failed, fall through to direct API
+		c.debugLog("MatchDetails: page fetch failed, falling back to API", "matchID", matchID, "error", err)
+	} else {
+		c.debugLog("MatchDetails: no pageURL stored, falling back to API", "matchID", matchID)
 	}
 
-	// Fallback: direct API endpoint (may return 403 if Turnstile is required)
+	// Fallback: direct API endpoint (likely returns 404 since FotMob removed it)
 	return c.matchDetailsFromAPI(ctx, matchID)
 }
 

--- a/internal/fotmob/page.go
+++ b/internal/fotmob/page.go
@@ -64,6 +64,46 @@ func fetchMatchDetailsFromPage(ctx context.Context, httpClient *http.Client, pag
 	return details, nil
 }
 
+// fetchLeagueFromPage fetches league data by scraping the league page HTML
+// and extracting fixtures/details from the __NEXT_DATA__ JSON.
+//
+// This replaces the old /api/leagues?id={id}&tab={tab} endpoint, which FotMob
+// removed (returns 404). The league page at /leagues/{id} contains the same data
+// in its __NEXT_DATA__ script tag, including all season matches in fixtures.allMatches.
+func fetchLeagueFromPage(ctx context.Context, httpClient *http.Client, leagueID int) (json.RawMessage, error) {
+	url := fmt.Sprintf("https://www.fotmob.com/leagues/%d", leagueID)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create league page request: %w", err)
+	}
+
+	req.Header.Set("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36")
+	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch league page: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("league page returned status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read league page body: %w", err)
+	}
+
+	pageProps, err := extractPageProps(string(body))
+	if err != nil {
+		return nil, fmt.Errorf("extract league page props: %w", err)
+	}
+
+	return pageProps, nil
+}
+
 // extractPageProps extracts the pageProps JSON from a Next.js page's __NEXT_DATA__ script tag.
 func extractPageProps(html string) (json.RawMessage, error) {
 	const marker = `__NEXT_DATA__`

--- a/scripts/validate_match_pipeline.go
+++ b/scripts/validate_match_pipeline.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/0xjuanma/golazo/internal/api"
+	"github.com/0xjuanma/golazo/internal/fotmob"
+)
+
+// Validates the full match data pipeline: league page fetch -> match list -> match details.
+// Tests both the stats view flow (finished matches) and live view flow.
+// Exit code 0 = all tests pass, 1 = failure.
+func main() {
+	client := fotmob.NewClient()
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	passed := 0
+	failed := 0
+
+	// Test 1: Fetch finished matches (stats view flow)
+	fmt.Println("=== Test 1: Stats view - finished matches ===")
+	var finishedMatches []api.Match
+	var testDate time.Time
+	for daysBack := 1; daysBack <= 7; daysBack++ {
+		testDate = time.Now().AddDate(0, 0, -daysBack)
+		matches, err := client.MatchesByDateWithTabs(ctx, testDate, []string{"results"})
+		if err != nil {
+			fmt.Printf("  Day -%d (%s): error: %v\n", daysBack, testDate.Format("2006-01-02"), err)
+			continue
+		}
+		if len(matches) > 0 {
+			finishedMatches = matches
+			fmt.Printf("  Day -%d (%s): found %d finished matches\n", daysBack, testDate.Format("2006-01-02"), len(matches))
+			break
+		}
+		fmt.Printf("  Day -%d (%s): no matches\n", daysBack, testDate.Format("2006-01-02"))
+	}
+
+	if len(finishedMatches) == 0 {
+		fmt.Println("  FAIL: No finished matches found in last 7 days")
+		failed++
+	} else {
+		// Verify match data quality
+		withScores := 0
+		withPageURL := 0
+		withLeague := 0
+		for _, m := range finishedMatches {
+			if m.HomeScore != nil && m.AwayScore != nil {
+				withScores++
+			}
+			if m.PageURL != "" {
+				withPageURL++
+			}
+			if m.League.ID > 0 {
+				withLeague++
+			}
+		}
+		fmt.Printf("  Total: %d | With scores: %d | With pageURL: %d | With league: %d\n",
+			len(finishedMatches), withScores, withPageURL, withLeague)
+
+		if withScores == 0 {
+			fmt.Println("  FAIL: No matches have scores")
+			failed++
+		} else if withPageURL == 0 {
+			fmt.Println("  FAIL: No matches have pageURL")
+			failed++
+		} else {
+			fmt.Println("  PASS")
+			passed++
+		}
+	}
+
+	// Test 2: Fetch match details for a finished match
+	fmt.Println("\n=== Test 2: Match details (page-based fetch) ===")
+	var testMatchID int
+	var testMatchName string
+	for _, m := range finishedMatches {
+		if m.PageURL != "" && m.HomeScore != nil {
+			testMatchID = m.ID
+			testMatchName = fmt.Sprintf("%s %d-%d %s", m.HomeTeam.Name, *m.HomeScore, *m.AwayScore, m.AwayTeam.Name)
+			break
+		}
+	}
+
+	if testMatchID == 0 {
+		fmt.Println("  SKIP: No suitable finished match for details test")
+	} else {
+		fmt.Printf("  Testing: %s (ID: %d)\n", testMatchName, testMatchID)
+		details, err := client.MatchDetails(ctx, testMatchID)
+		if err != nil {
+			fmt.Printf("  FAIL: MatchDetails error: %v\n", err)
+			failed++
+		} else if details == nil {
+			fmt.Println("  FAIL: MatchDetails returned nil")
+			failed++
+		} else {
+			fmt.Printf("  Score: %d - %d\n", *details.HomeScore, *details.AwayScore)
+			fmt.Printf("  Status: %s\n", details.Status)
+			fmt.Printf("  Events: %d\n", len(details.Events))
+			fmt.Printf("  Statistics: %d\n", len(details.Statistics))
+			fmt.Printf("  Home starting XI: %d\n", len(details.HomeStarting))
+			fmt.Printf("  Away starting XI: %d\n", len(details.AwayStarting))
+			fmt.Printf("  Venue: %s\n", details.Venue)
+			if details.HomeFormation != "" {
+				fmt.Printf("  Formations: %s vs %s\n", details.HomeFormation, details.AwayFormation)
+			}
+			if details.Highlight != nil {
+				fmt.Printf("  Highlight: %s\n", details.Highlight.URL)
+			}
+
+			// Validate key fields
+			issues := 0
+			if details.HomeScore == nil || details.AwayScore == nil {
+				fmt.Println("  WARNING: Missing score")
+				issues++
+			}
+			if len(details.Events) == 0 {
+				fmt.Println("  WARNING: No events")
+				issues++
+			}
+			if len(details.HomeStarting) == 0 {
+				fmt.Println("  WARNING: No home lineup")
+				issues++
+			}
+			if details.Venue == "" {
+				fmt.Println("  WARNING: No venue")
+				issues++
+			}
+
+			if issues > 0 {
+				fmt.Printf("  PASS (with %d warnings)\n", issues)
+			} else {
+				fmt.Println("  PASS")
+			}
+			passed++
+		}
+	}
+
+	// Test 3: Fetch today's fixtures (live view flow)
+	fmt.Println("\n=== Test 3: Live view - today's fixtures ===")
+	today := time.Now()
+	todayMatches, err := client.MatchesByDateWithTabs(ctx, today, []string{"fixtures"})
+	if err != nil {
+		fmt.Printf("  FAIL: Error fetching today's fixtures: %v\n", err)
+		failed++
+	} else {
+		liveCount := 0
+		upcomingCount := 0
+		for _, m := range todayMatches {
+			if m.Status == api.MatchStatusLive {
+				liveCount++
+			} else if m.Status == api.MatchStatusNotStarted {
+				upcomingCount++
+			}
+		}
+		fmt.Printf("  Live: %d | Upcoming: %d | Total: %d\n", liveCount, upcomingCount, len(todayMatches))
+		fmt.Println("  PASS (fixture fetch works, live/upcoming count is time-dependent)")
+		passed++
+	}
+
+	// Test 4: League table (also uses page-based fetch now)
+	fmt.Println("\n=== Test 4: League table ===")
+	table, err := client.LeagueTable(ctx, 47, "Premier League")
+	if err != nil {
+		fmt.Printf("  FAIL: LeagueTable error: %v\n", err)
+		failed++
+	} else if len(table) == 0 {
+		fmt.Println("  FAIL: Empty league table")
+		failed++
+	} else {
+		fmt.Printf("  %d teams in table\n", len(table))
+		if len(table) >= 3 {
+			for _, entry := range table[:3] {
+				fmt.Printf("    %d. %s - %dpts (%dW %dD %dL)\n",
+					entry.Position, entry.Team.Name, entry.Points,
+					entry.Won, entry.Drawn, entry.Lost)
+			}
+		}
+		fmt.Println("  PASS")
+		passed++
+	}
+
+	// Test 5: Progressive league fetch (used by live view)
+	fmt.Println("\n=== Test 5: Single league fetch (progressive loading) ===")
+	leagueMatches, err := client.MatchesForLeagueAndDate(ctx, 47, today, "fixtures")
+	if err != nil {
+		fmt.Printf("  FAIL: MatchesForLeagueAndDate error: %v\n", err)
+		failed++
+	} else {
+		fmt.Printf("  Premier League today: %d matches\n", len(leagueMatches))
+		for _, m := range leagueMatches {
+			status := string(m.Status)
+			score := ""
+			if m.HomeScore != nil && m.AwayScore != nil {
+				score = fmt.Sprintf(" (%d-%d)", *m.HomeScore, *m.AwayScore)
+			}
+			fmt.Printf("    %s vs %s [%s]%s\n", m.HomeTeam.Name, m.AwayTeam.Name, status, score)
+		}
+		fmt.Println("  PASS")
+		passed++
+	}
+
+	// Summary
+	fmt.Printf("\n=== Results: %d passed, %d failed ===\n", passed, failed)
+	if failed > 0 {
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
- Fix all data fetching after FotMob removed their JSON API endpoints (now returns 404)
- Switch to page-based HTML scraping via __NEXT_DATA__ for leagues, match details, and standings
- Fix upcoming matches not showing in live view unless stats view was visited first
- Add debug logging to fotmob client's match details fetch flow
-  Add scripts/validate_match_pipeline.go for e2e validation