### PR TITLE
fix[app]: resolve constant high CPU usage after repeated live match refreshes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **High CPU usage** - Fixed continuously growing CPU after repeated live match refreshes caused by duplicate poll and render tick chains
 
 ## [0.23.0] - 2026-04-08
 

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -185,9 +185,9 @@ func fetchMatchDetailsForceRefresh(client *fotmob.Client, matchID int, useMockDa
 
 // schedulePollTick schedules the next poll after 90 seconds.
 // When the tick fires, it sends pollTickMsg which triggers the actual API call.
-func schedulePollTick(matchID int) tea.Cmd {
+func schedulePollTick(matchID, gen int) tea.Cmd {
 	return tea.Tick(90*time.Second, func(t time.Time) tea.Msg {
-		return pollTickMsg{matchID: matchID}
+		return pollTickMsg{matchID: matchID, gen: gen}
 	})
 }
 

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -171,6 +171,7 @@ func (m model) loadMatchDetailsWithRefresh(matchID int, forceRefresh bool) (tea.
 	m.loading = true
 	m.liveViewLoading = true
 	m.polling = false // Reset polling state - this is a new match load, not a poll refresh
+	m.pollGen++       // Invalidate any in-flight poll timers from the previous chain
 
 	var cmd tea.Cmd
 	if forceRefresh {

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -164,6 +164,7 @@ func (m model) loadMatchDetails(matchID int) (tea.Model, tea.Cmd) {
 
 // loadMatchDetailsWithRefresh loads match details for the live matches view with optional cache bypass.
 func (m model) loadMatchDetailsWithRefresh(matchID int, forceRefresh bool) (tea.Model, tea.Cmd) {
+	chainAlive := m.polling || m.liveViewLoading // check before mutation: if true, tick chain is already running
 	m.liveUpdates = nil
 	m.lastEvents = nil
 	m.lastHomeScore = 0
@@ -180,6 +181,9 @@ func (m model) loadMatchDetailsWithRefresh(matchID int, forceRefresh bool) (tea.
 		cmd = fetchMatchDetails(m.fotmobClient, matchID, m.useMockData)
 	}
 
+	if chainAlive {
+		return m, tea.Batch(m.spinner.Tick, cmd)
+	}
 	return m, tea.Batch(m.spinner.Tick, ui.SpinnerTick(), cmd)
 }
 

--- a/internal/app/messages.go
+++ b/internal/app/messages.go
@@ -59,6 +59,7 @@ type statsDayDataMsg struct {
 // This triggers the actual API call with loading state visible.
 type pollTickMsg struct {
 	matchID int
+	gen     int // generation at scheduling time; dropped if model has moved on
 }
 
 // pollDisplayCompleteMsg is sent after minimum display time (1 second) has elapsed.

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -88,6 +88,7 @@ type model struct {
 	liveViewLoading  bool
 	statsViewLoading bool
 	polling          bool
+	pollGen          int    // incremented on each new load/refresh to invalidate stale poll timers
 	pendingSelection int    // Tracks which view is being preloaded (-1 = none, 0 = stats, 1 = live)
 	lastError        string // Last error message to display in UI (cleared on successful load)
 

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -594,7 +594,6 @@ func (m model) handleLiveMatches(msg liveMatchesMsg) (tea.Model, tea.Cmd) {
 	m.matches = displayMatches
 	m.selected = 0
 	m.loading = false
-	cmds = append(cmds, ui.SpinnerTick())
 
 	// Update list
 	m.liveMatchesList.SetItems(ui.ToMatchListItems(displayMatches))
@@ -746,9 +745,6 @@ func (m model) handleLiveBatchData(msg liveBatchDataMsg) (tea.Model, tea.Cmd) {
 	// Otherwise, fetch next batch
 	nextBatchIndex := msg.batchIndex + 1
 	cmds = append(cmds, fetchLiveBatchData(m.loadCtx, m.fotmobClient, m.useMockData, nextBatchIndex))
-
-	// Keep spinner running
-	cmds = append(cmds, ui.SpinnerTick())
 
 	return m, tea.Batch(cmds...)
 }
@@ -928,9 +924,6 @@ func (m model) handleStatsDayData(msg statsDayDataMsg) (tea.Model, tea.Cmd) {
 	nextDayIndex := msg.dayIndex + 1
 	cmds = append(cmds, fetchStatsDayData(m.loadCtx, m.fotmobClient, m.useMockData, nextDayIndex, m.statsTotalDays))
 
-	// Keep spinner running
-	cmds = append(cmds, ui.SpinnerTick())
-
 	return m, tea.Batch(cmds...)
 }
 
@@ -1063,7 +1056,7 @@ func (m model) handleMainViewCheck(msg mainViewCheckMsg) (tea.Model, tea.Cmd) {
 
 		// Keep spinners running if still loading
 		if m.statsViewLoading {
-			cmds = append(cmds, m.spinner.Tick, ui.SpinnerTick())
+			cmds = append(cmds, m.spinner.Tick)
 		}
 
 		return m, tea.Batch(cmds...)
@@ -1081,7 +1074,7 @@ func (m model) handleMainViewCheck(msg mainViewCheckMsg) (tea.Model, tea.Cmd) {
 
 		// Keep spinners running if still loading
 		if m.liveViewLoading {
-			cmds = append(cmds, m.spinner.Tick, ui.SpinnerTick())
+			cmds = append(cmds, m.spinner.Tick)
 		}
 
 		return m, tea.Batch(cmds...)
@@ -1115,7 +1108,6 @@ func (m model) handlePollTick(msg pollTickMsg) (tea.Model, tea.Cmd) {
 	// Also check for any new goals that might have been scored since last poll
 	return m, tea.Batch(
 		fetchPollMatchDetails(m.fotmobClient, msg.matchID, m.useMockData),
-		ui.SpinnerTick(),
 		schedulePollSpinnerHide(), // Hide spinner after 0.5 seconds
 	)
 }

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -145,7 +145,7 @@ func (m model) handleLiveUpdate(msg liveUpdateMsg) (tea.Model, tea.Cmd) {
 
 	// Continue polling if match is live
 	if m.polling && m.matchDetails != nil && m.matchDetails.Status == api.MatchStatusLive {
-		return m, schedulePollTick(m.matchDetails.ID)
+		return m, schedulePollTick(m.matchDetails.ID, m.pollGen)
 	}
 
 	m.loading = false
@@ -275,7 +275,7 @@ func (m model) handleMatchDetails(msg matchDetailsMsg) (tea.Model, tea.Cmd) {
 
 			m.polling = true
 			// Schedule next poll tick (90 seconds from now)
-			cmds = append(cmds, schedulePollTick(msg.details.ID))
+			cmds = append(cmds, schedulePollTick(msg.details.ID, m.pollGen))
 		} else {
 			m.loading = false
 			m.polling = false
@@ -1095,6 +1095,11 @@ func (m model) handleMainViewCheck(msg mainViewCheckMsg) (tea.Model, tea.Cmd) {
 func (m model) handlePollTick(msg pollTickMsg) (tea.Model, tea.Cmd) {
 	// Only process if we're still in live view and polling is active
 	if m.currentView != viewLiveMatches || !m.polling {
+		return m, nil
+	}
+
+	// Drop stale timers from previous load/refresh generations
+	if msg.gen != m.pollGen {
 		return m, nil
 	}
 


### PR DESCRIPTION
## Summary
Fixes https://github.com/0xjuanma/golazo/issues/134, the bug where repeatedly pressing `r` on a live match caused CPU usage to climb continuously and never return to baseline.

## Updates
- Added a generation counter to poll timers so stale in-flight timers from previous refreshes are silently dropped instead of spawning parallel poll chains
- Removed 6 redundant SpinnerTick calls that were spawning independent 70ms render loops on top of an already self-managing animation tick chain
- Guarded the SpinnerTick kickstart in match detail refresh to only fire when the tick chain is not already running