### PR TITLE
feat[live-view]: add statistics and standings dialogs to live matches view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Live Statistics & Standings** - Press `x` for match statistics (possession, shots, etc.) or `s` for league standings while viewing any live match
 
 ### Changed
 

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/0xjuanma/golazo/internal/api"
 	"github.com/0xjuanma/golazo/internal/constants"
@@ -32,6 +33,15 @@ const (
 	viewStats
 	viewSettings
 )
+
+// standingsCacheEntry holds a fetched standings result with a timestamp for TTL checks.
+type standingsCacheEntry struct {
+	standings  []api.LeagueTableEntry
+	leagueName string
+	homeTeamID int
+	awayTeamID int
+	fetchedAt  time.Time
+}
 
 // model holds the application state.
 // Fields are organized by concern: display, data, UI components, and configuration.
@@ -109,6 +119,9 @@ type model struct {
 
 	// Dialog overlay for modal dialogs
 	dialogOverlay *ui.DialogOverlay
+
+	// Standings cache keyed by league ID — limits refetches to once per 5 minutes
+	standingsCache map[int]*standingsCacheEntry
 
 	// API clients
 	fotmobClient *fotmob.Client
@@ -218,6 +231,7 @@ func New(useMockData bool, debugMode bool, isDevBuild bool, newVersionAvailable 
 	return model{
 		currentView:            viewMain,
 		matchDetailsCache:      make(map[int]*api.MatchDetails),
+		standingsCache:         make(map[int]*standingsCacheEntry),
 		useMockData:            useMockData,
 		debugMode:              debugMode,
 		isDevBuild:             isDevBuild,

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -383,7 +383,11 @@ func (m model) resetToMainView() (tea.Model, tea.Cmd) {
 func (m model) handleLiveMatchesSelection(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	// Trigger dialogs only when not in filter mode to avoid intercepting typed characters
 	if m.liveMatchesList.FilterState() != list.Filtering {
-		if msg.String() == "x" && m.matchDetails != nil && len(m.matchDetails.Statistics) > 0 {
+		if msg.String() == "x" {
+			if m.matchDetails == nil || len(m.matchDetails.Statistics) == 0 {
+				m.lastError = constants.ErrorNoStatistics
+				return m, nil
+			}
 			m.openStatisticsDialog()
 			return m, nil
 		}
@@ -1341,6 +1345,7 @@ func (m model) handleStandings(msg standingsMsg) (tea.Model, tea.Cmd) {
 
 	if len(msg.standings) == 0 {
 		m.debugLog("handleStandings: no standings data, skipping dialog")
+		m.lastError = constants.ErrorNoStandings
 		return m, nil
 	}
 	if m.dialogOverlay == nil {

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -259,6 +259,12 @@ func (m model) handleMatchDetails(msg matchDetailsMsg) (tea.Model, tea.Cmd) {
 		// stay in sync after every 90s poll without waiting for the 5-min refresh.
 		m.syncMatchScoreInList(msg.details.ID, homeScore, awayScore, msg.details.LiveTime)
 
+		// Keep the statistics dialog fresh if the user has it open during a poll cycle
+		if m.dialogOverlay != nil && m.dialogOverlay.ContainsDialog(ui.StatisticsDialogID) {
+			m.dialogOverlay.CloseDialog(ui.StatisticsDialogID)
+			m.openStatisticsDialog()
+		}
+
 		// Parse ALL events to rebuild the live updates list
 		// This ensures proper ordering (descending by minute) and uniqueness
 		m.liveUpdates = m.parser.ParseEvents(msg.details.Events, msg.details.HomeTeam, msg.details.AwayTeam)

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -387,6 +387,16 @@ func (m model) handleLiveMatchesSelection(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.openStatisticsDialog()
 			return m, nil
 		}
+		if msg.String() == "s" && m.matchDetails != nil {
+			return m, fetchStandings(
+				m.fotmobClient,
+				m.matchDetails.League.ID,
+				m.matchDetails.League.Name,
+				m.matchDetails.League.ParentLeagueID,
+				m.matchDetails.HomeTeam.ID,
+				m.matchDetails.AwayTeam.ID,
+			)
+		}
 	}
 
 	// Capture selected item BEFORE Update (critical for filter mode - selection changes after filter clears)

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -375,6 +375,14 @@ func (m model) resetToMainView() (tea.Model, tea.Cmd) {
 
 // handleLiveMatchesSelection handles list navigation in live matches view.
 func (m model) handleLiveMatchesSelection(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	// Trigger dialogs only when not in filter mode to avoid intercepting typed characters
+	if m.liveMatchesList.FilterState() != list.Filtering {
+		if msg.String() == "x" && m.matchDetails != nil && len(m.matchDetails.Statistics) > 0 {
+			m.openStatisticsDialog()
+			return m, nil
+		}
+	}
+
 	// Capture selected item BEFORE Update (critical for filter mode - selection changes after filter clears)
 	var preUpdateMatchID int
 	if preItem := m.liveMatchesList.SelectedItem(); preItem != nil {

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -388,9 +388,15 @@ func (m model) handleLiveMatchesSelection(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		if msg.String() == "s" && m.matchDetails != nil {
+			leagueID := m.matchDetails.League.ID
+			if entry, ok := m.standingsCache[leagueID]; ok && time.Since(entry.fetchedAt) < 5*time.Minute {
+				dialog := ui.NewStandingsDialog(entry.leagueName, entry.standings, entry.homeTeamID, entry.awayTeamID)
+				m.dialogOverlay.OpenDialog(dialog)
+				return m, nil
+			}
 			return m, fetchStandings(
 				m.fotmobClient,
-				m.matchDetails.League.ID,
+				leagueID,
 				m.matchDetails.League.Name,
 				m.matchDetails.League.ParentLeagueID,
 				m.matchDetails.HomeTeam.ID,
@@ -1343,6 +1349,13 @@ func (m model) handleStandings(msg standingsMsg) (tea.Model, tea.Cmd) {
 	}
 
 	m.debugLog(fmt.Sprintf("handleStandings: creating dialog with %d entries", len(msg.standings)))
+	m.standingsCache[msg.leagueID] = &standingsCacheEntry{
+		standings:  msg.standings,
+		leagueName: msg.leagueName,
+		homeTeamID: msg.homeTeamID,
+		awayTeamID: msg.awayTeamID,
+		fetchedAt:  time.Now(),
+	}
 	dialog := ui.NewStandingsDialog(
 		msg.leagueName,
 		msg.standings,

--- a/internal/constants/strings.go
+++ b/internal/constants/strings.go
@@ -39,7 +39,7 @@ const (
 // Help text
 const (
 	HelpMainMenu           = "↑/↓: navigate  Enter: select  q: quit"
-	HelpMatchesView        = "↑/↓: navigate  r: refresh  x: statistics  /: filter  Esc: back  q: quit"
+	HelpMatchesView        = "↑/↓: navigate  r: refresh  x: statistics  s: standings  /: filter  Esc: back  q: quit"
 	HelpSettingsView       = "↑/↓: navigate  ←/→: switch tabs  Space: toggle  /: filter  Enter: save  Esc: back"
 	HelpStatsView          = "h/l: date range  j/k: navigate  Tab: focus details  ↑/↓: scroll when focused  r: refresh details  /: filter  Esc: back"
 	HelpStatsViewUnfocused = "Tab: focus details"

--- a/internal/constants/strings.go
+++ b/internal/constants/strings.go
@@ -47,6 +47,10 @@ const (
 	HelpStandingsDialog    = "Esc: close"
 	HelpFormationsDialog   = "Tab/←/→: switch team  Esc: close"
 	HelpStatisticsDialog   = "↑/↓: navigate  Esc: close"
+
+	// Edge case user-facing hints
+	ErrorNoStatistics = "No statistics available yet"
+	ErrorNoStandings  = "No standings available"
 )
 
 // Status text

--- a/internal/constants/strings.go
+++ b/internal/constants/strings.go
@@ -39,7 +39,7 @@ const (
 // Help text
 const (
 	HelpMainMenu           = "↑/↓: navigate  Enter: select  q: quit"
-	HelpMatchesView        = "↑/↓: navigate  r: refresh details  /: filter  Esc: back  q: quit"
+	HelpMatchesView        = "↑/↓: navigate  r: refresh  x: statistics  /: filter  Esc: back  q: quit"
 	HelpSettingsView       = "↑/↓: navigate  ←/→: switch tabs  Space: toggle  /: filter  Enter: save  Esc: back"
 	HelpStatsView          = "h/l: date range  j/k: navigate  Tab: focus details  ↑/↓: scroll when focused  r: refresh details  /: filter  Esc: back"
 	HelpStatsViewUnfocused = "Tab: focus details"

--- a/internal/ui/list_panels.go
+++ b/internal/ui/list_panels.go
@@ -229,7 +229,8 @@ func RenderMultiPanelViewWithList(width, height int, listModel list.Model, detai
 		leftWidth = width - rightWidth - 1
 	}
 
-	panelHeight := availableHeight - 2
+	helpBar := neonDimStyle.Width(width).Align(lipgloss.Center).Render(constants.HelpMatchesView)
+	panelHeight := availableHeight - 3
 
 	leftPanel := RenderLiveMatchesListPanel(leftWidth, panelHeight, listModel, upcomingMatches)
 	rightPanel := renderMatchDetailsPanelWithPolling(rightWidth, panelHeight, details, liveUpdates, sp, loading, pollingSpinner, isPolling, goalLinks)
@@ -247,10 +248,10 @@ func RenderMultiPanelViewWithList(width, height int, listModel list.Model, detai
 			Width(width).
 			Align(lipgloss.Center)
 		errorBanner := errorStyle.Render(lastError + "  " + constants.ErrorRetryHint)
-		return lipgloss.JoinVertical(lipgloss.Left, spinnerArea, statusBanner, errorBanner, panels)
+		return lipgloss.JoinVertical(lipgloss.Left, spinnerArea, statusBanner, errorBanner, panels, helpBar)
 	}
 
-	return lipgloss.JoinVertical(lipgloss.Left, spinnerArea, statusBanner, panels)
+	return lipgloss.JoinVertical(lipgloss.Left, spinnerArea, statusBanner, panels, helpBar)
 }
 
 // RenderStatsViewWithList renders the stats view with list component.


### PR DESCRIPTION
## Summary
Resolves https://github.com/0xjuanma/golazo/issues/112. Surfaces existing match statistics and league standings as on-demand dialogs in the **live view,** reusing the same popup infrastructure already available in the finished matches view.

## Updates
- Added `x` key to open live match statistics dialog (possession, shots, corners, etc.)
- Added `s` key to open league standings dialog with 5-minute cache to limit API calls
- Statistics dialog auto-refreshes on each 90s poll cycle if left open
- Added user-facing hints when statistics or standings data is unavailable