### PR TITLE
fix[ui/hyperlink]: fix OSC 8 link rendering for non-supporting terminals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Homebrew Update** - Fixed `golazo -u` falling back to the install script when brew successfully built the new version but failed the link step due to a conflicting binary
+- **Link Rendering** - Fixed highlight and goal replay links not being clickable in macOS Terminal.app and other terminals that don't support OSC 8; links now render as visible bracketed URLs that Terminal.app detects natively on right-click
 
 ## [0.24.0] - 2026-05-03
 

--- a/internal/ui/hyperlink.go
+++ b/internal/ui/hyperlink.go
@@ -31,8 +31,9 @@ func Hyperlink(text, url string) string {
 		return fmt.Sprintf("%s%s%s%s%s%s", oscStart, url, oscEnd, text, oscStart, oscEnd)
 	}
 
-	// Fallback: just return text (caller can handle showing URL separately)
-	return text
+	// Fallback: render URL as visible text so the terminal's native URL scanner
+	// (e.g. Terminal.app right-click → "Open URL") can detect and open it.
+	return text + "  " + url
 }
 
 // HyperlinkWithFallback creates a hyperlink with a visible fallback indicator.
@@ -76,9 +77,12 @@ func CreateGoalLinkDisplay(goalText, replayURL string) string {
 		return goalText + " " + linkedIndicator
 	}
 
-	// Terminal doesn't support hyperlinks - return unchanged text
-	// This ensures no visible change when link can't be used
-	return goalText
+	// Fallback: render URL as visible text so the terminal's native URL scanner
+	// can detect and offer right-click → "Open URL".
+	if goalText == "" {
+		return "▶ " + replayURL
+	}
+	return goalText + " ▶ " + replayURL
 }
 
 // supportsHyperlinks detects if the terminal likely supports OSC 8 hyperlinks.
@@ -97,9 +101,15 @@ func supportsHyperlinks() bool {
 		"alacritty",
 	}
 
+	// Explicitly exclude terminals known not to support OSC 8.
+	// This must run before the supportingTerms loop because Apple_Terminal sets
+	// TERM=xterm-256color which would otherwise match and return true.
+	if termProgram == "Apple_Terminal" {
+		return false
+	}
+
 	supportingPrograms := []string{
 		"iTerm.app",
-		"Apple_Terminal", // Terminal.app (partial support)
 		"vscode",
 		"Hyper",
 		"WezTerm",

--- a/internal/ui/hyperlink.go
+++ b/internal/ui/hyperlink.go
@@ -33,7 +33,7 @@ func Hyperlink(text, url string) string {
 
 	// Fallback: render URL as visible text so the terminal's native URL scanner
 	// (e.g. Terminal.app right-click → "Open URL") can detect and open it.
-	return text + "  " + url
+	return text + "  [" + url + "]"
 }
 
 // HyperlinkWithFallback creates a hyperlink with a visible fallback indicator.
@@ -80,9 +80,9 @@ func CreateGoalLinkDisplay(goalText, replayURL string) string {
 	// Fallback: render URL as visible text so the terminal's native URL scanner
 	// can detect and offer right-click → "Open URL".
 	if goalText == "" {
-		return "▶ " + replayURL
+		return "▶ [" + replayURL + "]"
 	}
-	return goalText + " ▶ " + replayURL
+	return goalText + " ▶ [" + replayURL + "]"
 }
 
 // supportsHyperlinks detects if the terminal likely supports OSC 8 hyperlinks.

--- a/internal/ui/hyperlink_test.go
+++ b/internal/ui/hyperlink_test.go
@@ -1,0 +1,117 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSupportsHyperlinks(t *testing.T) {
+	tests := []struct {
+		name        string
+		term        string
+		termProgram string
+		wtSession   string
+		kitty       string
+		want        bool
+	}{
+		{
+			name:        "Apple_Terminal is excluded even with xterm-256color TERM",
+			term:        "xterm-256color",
+			termProgram: "Apple_Terminal",
+			want:        false,
+		},
+		{
+			name:        "iTerm2 is supported",
+			termProgram: "iTerm.app",
+			want:        true,
+		},
+		{
+			name:        "xterm-256color with no TERM_PROGRAM is supported",
+			term:        "xterm-256color",
+			termProgram: "",
+			want:        true,
+		},
+		{
+			name: "dumb terminal is not supported",
+			term: "dumb",
+			want: false,
+		},
+		{
+			name: "empty TERM is not supported",
+			term: "",
+			want: false,
+		},
+		{
+			name:      "Windows Terminal (WT_SESSION) is supported",
+			wtSession: "some-session-id",
+			want:      true,
+		},
+		{
+			name:  "Kitty is supported",
+			kitty: "1",
+			want:  true,
+		},
+		{
+			name:        "WezTerm is supported",
+			termProgram: "WezTerm",
+			want:        true,
+		},
+		{
+			name:        "vscode is supported",
+			termProgram: "vscode",
+			want:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("TERM", tt.term)
+			t.Setenv("TERM_PROGRAM", tt.termProgram)
+			t.Setenv("WT_SESSION", tt.wtSession)
+			t.Setenv("KITTY_WINDOW_ID", tt.kitty)
+
+			got := supportsHyperlinks()
+			if got != tt.want {
+				t.Errorf("supportsHyperlinks() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHyperlinkFallbackContainsURL(t *testing.T) {
+	t.Setenv("TERM", "dumb")
+	t.Setenv("TERM_PROGRAM", "")
+	t.Setenv("WT_SESSION", "")
+	t.Setenv("KITTY_WINDOW_ID", "")
+
+	result := Hyperlink("link text", "https://example.com")
+	if !strings.Contains(result, "https://example.com") {
+		t.Errorf("Hyperlink() fallback = %q, want it to contain the URL", result)
+	}
+}
+
+func TestCreateGoalLinkDisplayFallbackContainsURL(t *testing.T) {
+	t.Setenv("TERM", "dumb")
+	t.Setenv("TERM_PROGRAM", "")
+	t.Setenv("WT_SESSION", "")
+	t.Setenv("KITTY_WINDOW_ID", "")
+
+	url := "https://reddit.com/r/soccer/comments/abc"
+
+	t.Run("empty goalText", func(t *testing.T) {
+		result := CreateGoalLinkDisplay("", url)
+		if !strings.Contains(result, url) {
+			t.Errorf("CreateGoalLinkDisplay() fallback = %q, want it to contain the URL", result)
+		}
+	})
+
+	t.Run("with goalText", func(t *testing.T) {
+		result := CreateGoalLinkDisplay("Messi 45'", url)
+		if !strings.Contains(result, url) {
+			t.Errorf("CreateGoalLinkDisplay() fallback = %q, want it to contain the URL", result)
+		}
+		if !strings.Contains(result, "Messi 45'") {
+			t.Errorf("CreateGoalLinkDisplay() fallback = %q, want it to contain the goalText", result)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
Fixes https://github.com/0xjuanma/golazo/issues/142. Resolves clickable links not working in macOS Terminal.app and other terminals that don't support OSC 8 hyperlinks.

## Updates
- Fixed false-positive OSC 8 detection for Apple_Terminal (TERM=xterm-256color was matching before TERM_PROGRAM exclusion check)
- Updated fallback rendering to output raw URLs as visible bracketed text so Terminal.app's native URL scanner picks them up on right-click