### PR TITLE
feat[ui/match_details]: display aggregate score for two-legged knockout ties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Aggregate Score** - Finished knockout matches (Champions League, Europa League, etc.) now display the aggregate score and eliminated team below the match score in the details panel
 
 ### Changed
 

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -123,6 +123,10 @@ type MatchDetails struct {
 
 	// Highlight video (if available)
 	Highlight *MatchHighlight `json:"highlight,omitempty"` // Official highlight video link
+
+	// Aggregate score (two-legged knockout ties only)
+	AggregateScore     string `json:"aggregate_score,omitempty"`      // e.g. "5 - 7"
+	WhoLostOnAggregate string `json:"who_lost_on_aggregate,omitempty"` // team name eliminated on aggregate
 }
 
 // MatchHighlight represents an official highlight video for a match

--- a/internal/fotmob/types.go
+++ b/internal/fotmob/types.go
@@ -142,7 +142,9 @@ type fotmobMatchDetails struct {
 			Name  string `json:"name"`
 			Score int    `json:"score"`
 		} `json:"teams"`
-		Status status `json:"status"`
+		Status              status `json:"status"`
+		AggregatedStr       string `json:"aggregatedStr,omitempty"`
+		WhoLostOnAggregated string `json:"whoLostOnAggregated,omitempty"`
 	} `json:"header"`
 	General struct {
 		MatchID  string `json:"matchId"`
@@ -449,6 +451,12 @@ func (m fotmobMatchDetails) toAPIMatchDetails() *api.MatchDetails {
 				}
 			}
 		}
+	}
+
+	// Aggregate score (two-legged knockout ties)
+	if m.Header.AggregatedStr != "" {
+		details.AggregateScore = m.Header.AggregatedStr
+		details.WhoLostOnAggregate = m.Header.WhoLostOnAggregated
 	}
 
 	// Convert events from content.matchFacts.events

--- a/internal/fotmob/types_test.go
+++ b/internal/fotmob/types_test.go
@@ -288,3 +288,49 @@ func TestGetParentLeagueID(t *testing.T) {
 		})
 	}
 }
+
+func TestToAPIMatchDetails_AggregateScore(t *testing.T) {
+	m := fotmobMatchDetails{}
+	m.Header.Status.Finished = boolPtr(true)
+	m.Header.AggregatedStr = "5 - 7"
+	m.Header.WhoLostOnAggregated = "Juventus"
+	m.Header.Teams = []struct {
+		ID    int    `json:"id"`
+		Name  string `json:"name"`
+		Score int    `json:"score"`
+	}{
+		{ID: 1, Name: "Galatasaray", Score: 5},
+		{ID: 2, Name: "Juventus", Score: 2},
+	}
+
+	got := m.toAPIMatchDetails()
+
+	if got.AggregateScore != "5 - 7" {
+		t.Errorf("AggregateScore = %q, want %q", got.AggregateScore, "5 - 7")
+	}
+	if got.WhoLostOnAggregate != "Juventus" {
+		t.Errorf("WhoLostOnAggregate = %q, want %q", got.WhoLostOnAggregate, "Juventus")
+	}
+}
+
+func TestToAPIMatchDetails_NoAggregateScore(t *testing.T) {
+	m := fotmobMatchDetails{}
+	m.Header.Status.Finished = boolPtr(true)
+	m.Header.Teams = []struct {
+		ID    int    `json:"id"`
+		Name  string `json:"name"`
+		Score int    `json:"score"`
+	}{
+		{ID: 1, Name: "Arsenal", Score: 2},
+		{ID: 2, Name: "Chelsea", Score: 1},
+	}
+
+	got := m.toAPIMatchDetails()
+
+	if got.AggregateScore != "" {
+		t.Errorf("AggregateScore = %q, want empty for non-knockout match", got.AggregateScore)
+	}
+	if got.WhoLostOnAggregate != "" {
+		t.Errorf("WhoLostOnAggregate = %q, want empty for non-knockout match", got.WhoLostOnAggregate)
+	}
+}

--- a/internal/ui/match_details.go
+++ b/internal/ui/match_details.go
@@ -82,6 +82,11 @@ func RenderMatchDetails(cfg MatchDetailsConfig) (headerContent, scrollableConten
 	}
 	headerLines = append(headerLines, "")
 
+	// Aggregate score (two-legged knockout ties)
+	if details.AggregateScore != "" {
+		headerLines = append(headerLines, renderAggregateSection(details, contentWidth)...)
+	}
+
 	// Match context (detailed info)
 	headerLines = append(headerLines, renderMatchContext(details, contentWidth)...)
 
@@ -193,6 +198,38 @@ func renderMatchContext(details *api.MatchDetails, contentWidth int) []string {
 		lines = append(lines, neonLabelStyle.Render("Duration:    ")+neonValueStyle.Render("After Extra Time"))
 	}
 
+	return lines
+}
+
+func renderAggregateSection(details *api.MatchDetails, contentWidth int) []string {
+	var lines []string
+
+	aggHeader := lipgloss.NewStyle().
+		Foreground(neonCyan).
+		Bold(true).
+		Width(contentWidth).
+		Align(lipgloss.Center).
+		Render("AGG.")
+	lines = append(lines, aggHeader)
+
+	aggScore := lipgloss.NewStyle().
+		Foreground(neonCyan).
+		Bold(true).
+		Width(contentWidth).
+		Align(lipgloss.Center).
+		Render(details.AggregateScore)
+	lines = append(lines, aggScore)
+
+	if details.WhoLostOnAggregate != "" {
+		eliminated := lipgloss.NewStyle().
+			Foreground(neonDim).
+			Width(contentWidth).
+			Align(lipgloss.Center).
+			Render(details.WhoLostOnAggregate + " eliminated")
+		lines = append(lines, eliminated)
+	}
+
+	lines = append(lines, "")
 	return lines
 }
 

--- a/internal/ui/match_details_test.go
+++ b/internal/ui/match_details_test.go
@@ -1,0 +1,96 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/0xjuanma/golazo/internal/api"
+)
+
+func TestRenderAggregateSection_WithData(t *testing.T) {
+	details := &api.MatchDetails{
+		AggregateScore:     "5 - 7",
+		WhoLostOnAggregate: "Juventus",
+	}
+
+	lines := renderAggregateSection(details, 60)
+	joined := strings.Join(lines, "\n")
+
+	if !strings.Contains(joined, "AGG.") {
+		t.Errorf("expected output to contain %q, got:\n%s", "AGG.", joined)
+	}
+	if !strings.Contains(joined, "5 - 7") {
+		t.Errorf("expected output to contain %q, got:\n%s", "5 - 7", joined)
+	}
+	if !strings.Contains(joined, "Juventus eliminated") {
+		t.Errorf("expected output to contain %q, got:\n%s", "Juventus eliminated", joined)
+	}
+}
+
+func TestRenderAggregateSection_NoEliminated(t *testing.T) {
+	details := &api.MatchDetails{
+		AggregateScore:     "3 - 1",
+		WhoLostOnAggregate: "",
+	}
+
+	lines := renderAggregateSection(details, 60)
+	joined := strings.Join(lines, "\n")
+
+	if !strings.Contains(joined, "AGG.") {
+		t.Errorf("expected output to contain %q", "AGG.")
+	}
+	if !strings.Contains(joined, "3 - 1") {
+		t.Errorf("expected output to contain %q", "3 - 1")
+	}
+	if strings.Contains(joined, "eliminated") {
+		t.Errorf("expected no %q line when WhoLostOnAggregate is empty", "eliminated")
+	}
+}
+
+func TestRenderMatchDetails_AggregateSection_Rendered(t *testing.T) {
+	home, away := 3, 2
+	details := &api.MatchDetails{
+		Match: api.Match{
+			Status:   api.MatchStatusFinished,
+			HomeTeam: api.Team{Name: "Galatasaray", ShortName: "Gala"},
+			AwayTeam: api.Team{Name: "Juventus", ShortName: "Juve"},
+		},
+		AggregateScore:     "5 - 7",
+		WhoLostOnAggregate: "Juventus",
+	}
+	details.HomeScore = &home
+	details.AwayScore = &away
+
+	header, _ := RenderMatchDetails(MatchDetailsConfig{
+		Width:   80,
+		Height:  40,
+		Details: details,
+	})
+
+	if !strings.Contains(header, "AGG.") {
+		t.Errorf("RenderMatchDetails header should contain %q when AggregateScore is set", "AGG.")
+	}
+}
+
+func TestRenderMatchDetails_NoAggregateSection_WhenEmpty(t *testing.T) {
+	home, away := 2, 1
+	details := &api.MatchDetails{
+		Match: api.Match{
+			Status:   api.MatchStatusFinished,
+			HomeTeam: api.Team{Name: "Arsenal", ShortName: "ARS"},
+			AwayTeam: api.Team{Name: "Chelsea", ShortName: "CHE"},
+		},
+	}
+	details.HomeScore = &home
+	details.AwayScore = &away
+
+	header, _ := RenderMatchDetails(MatchDetailsConfig{
+		Width:   80,
+		Height:  40,
+		Details: details,
+	})
+
+	if strings.Contains(header, "AGG.") {
+		t.Errorf("RenderMatchDetails header should NOT contain %q for non-knockout match", "AGG.")
+	}
+}


### PR DESCRIPTION
## Summary
Resolves https://github.com/0xjuanma/golazo/issues/140. Surfaces aggregate score data already returned by the FotMob match details API but previously discarded. Finished knockout matches now show a prominent AGG. section (score + eliminated team) directly below the large match score in the details panel.

## Updates
- Added `AggregatedStr` and `WhoLostOnAggregated` fields to `fotmobMatchDetails.Header` and wired them through to `api.MatchDetails`
- Added `renderAggregateSection()` to the details panel, styled consistently with the existing penalties section
- Non-knockout matches are unaffected — the section is guarded by a non-empty check