### PR TITLE
fix[ui]: show platform-correct debug log path in --debug banner and flag help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **Debug Log Hint** - The `--debug` banner and `--debug` flag help now display the platform-correct log path (`~/.config/golazo/golazo_debug.log` on Linux per XDG, `~/.golazo/golazo_debug.log` on macOS/Windows) instead of a hardcoded macOS path.
 - **World Cup Hints** - Removed a redundant tab hint above the groups list so each sub-view shows a single, accurate help line.
 
 ## [0.25.0] - 2026-05-31

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -190,7 +190,7 @@ func Execute() {
 
 func init() {
 	rootCmd.Flags().BoolVar(&mockFlag, "mock", false, "Use mock data for all views instead of real API data")
-	rootCmd.Flags().BoolVar(&debugFlag, "debug", false, "Enable debug logging to ~/.golazo/golazo_debug.log")
+	rootCmd.Flags().BoolVar(&debugFlag, "debug", false, "Enable debug logging to "+data.DebugLogPath())
 	rootCmd.Flags().BoolVarP(&updateFlag, "update", "u", false, "Update golazo to the latest version")
 	rootCmd.Flags().BoolVarP(&versionFlag, "version", "v", false, "Display version information")
 }

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -308,7 +308,8 @@ func newFotmobClient(logger *slog.Logger) *fotmob.Client {
 	return c
 }
 
-// initLogger creates a structured logger. When debugMode is true, logs to ~/.golazo/golazo_debug.log.
+// initLogger creates a structured logger. When debugMode is true, logs to the
+// platform-specific debug log location (see data.DebugLogPath).
 // Otherwise returns a no-op logger. The caller should store the returned *os.File and close it on exit.
 func initLogger(debugMode bool) (*slog.Logger, *os.File) {
 	if !debugMode {

--- a/internal/data/settings_test.go
+++ b/internal/data/settings_test.go
@@ -3,6 +3,7 @@ package data
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -215,6 +216,58 @@ func TestGetLeaguesForRegion(t *testing.T) {
 	if !found {
 		t.Error("Premier League (ID=47) not found in Europe region")
 	}
+}
+
+func TestDebugLogPath(t *testing.T) {
+	// Helper: verify DebugLogPath does not create the directory it points to.
+	assertNoCreate := func(t *testing.T, p string) {
+		t.Helper()
+		dir := filepath.Dir(p)
+		if _, err := os.Stat(dir); err == nil {
+			t.Errorf("DebugLogPath created directory %q; helper must be pure", dir)
+		}
+	}
+
+	t.Run("linux with XDG_CONFIG_HOME", func(t *testing.T) {
+		if runtime.GOOS != "linux" {
+			t.Skip("linux-only branch")
+		}
+		xdg := t.TempDir()
+		t.Setenv("XDG_CONFIG_HOME", xdg)
+
+		got := DebugLogPath()
+		want := filepath.Join(xdg, "golazo", "golazo_debug.log")
+		if got != want {
+			t.Errorf("DebugLogPath() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("linux without XDG_CONFIG_HOME", func(t *testing.T) {
+		if runtime.GOOS != "linux" {
+			t.Skip("linux-only branch")
+		}
+		t.Setenv("XDG_CONFIG_HOME", "")
+
+		got := DebugLogPath()
+		want := filepath.Join("~", ".config", "golazo", "golazo_debug.log")
+		if got != want {
+			t.Errorf("DebugLogPath() = %q, want %q", got, want)
+		}
+		assertNoCreate(t, got)
+	})
+
+	t.Run("non-linux", func(t *testing.T) {
+		if runtime.GOOS == "linux" {
+			t.Skip("non-linux branch")
+		}
+
+		got := DebugLogPath()
+		want := filepath.Join("~", ".golazo", "golazo_debug.log")
+		if got != want {
+			t.Errorf("DebugLogPath() = %q, want %q", got, want)
+		}
+		assertNoCreate(t, got)
+	})
 }
 
 func TestConfigDir(t *testing.T) {

--- a/internal/data/storage.go
+++ b/internal/data/storage.go
@@ -48,6 +48,23 @@ func ConfigDir() (string, error) {
 	return configPath, nil
 }
 
+// DebugLogPath returns the user-facing path to the debug log file, with the
+// home directory represented as "~" for display purposes. It is platform-aware
+// and mirrors the location used by ConfigDir, but performs no filesystem I/O
+// and does not create any directories. Safe to call from init() / flag help.
+func DebugLogPath() string {
+	const logFile = "golazo_debug.log"
+
+	if runtime.GOOS == "linux" {
+		if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+			return filepath.Join(xdg, "golazo", logFile)
+		}
+		return filepath.Join("~", ".config", "golazo", logFile)
+	}
+
+	return filepath.Join("~", configDir, logFile)
+}
+
 // CacheDir returns the path to the golazo cache directory.
 // Uses os.UserCacheDir() which returns:
 //   - Linux: ~/.cache/golazo (or $XDG_CACHE_HOME/golazo)

--- a/internal/ui/status_banner_test.go
+++ b/internal/ui/status_banner_test.go
@@ -1,0 +1,27 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/0xjuanma/golazo/internal/constants"
+	"github.com/0xjuanma/golazo/internal/data"
+)
+
+func TestRenderStatusBanner_DebugUsesDebugLogPath(t *testing.T) {
+	got := renderStatusBanner(constants.StatusBannerDebug, 120)
+	want := data.DebugLogPath()
+
+	if !strings.Contains(got, want) {
+		t.Errorf("renderStatusBanner(StatusBannerDebug) = %q; want it to contain %q", got, want)
+	}
+	if !strings.Contains(got, "[DEBUG MODE]") {
+		t.Errorf("renderStatusBanner(StatusBannerDebug) = %q; want it to contain %q", got, "[DEBUG MODE]")
+	}
+}
+
+func TestRenderStatusBanner_NoneReturnsEmpty(t *testing.T) {
+	if got := renderStatusBanner(constants.StatusBannerNone, 120); got != "" {
+		t.Errorf("renderStatusBanner(StatusBannerNone) = %q; want empty", got)
+	}
+}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"github.com/0xjuanma/golazo/internal/constants"
+	"github.com/0xjuanma/golazo/internal/data"
 	"github.com/0xjuanma/golazo/internal/ui/design"
 	"github.com/charmbracelet/lipgloss"
 )
@@ -23,7 +24,7 @@ func renderStatusBanner(bannerType constants.StatusBannerType, width int) string
 
 	switch bannerType {
 	case constants.StatusBannerDebug:
-		message = "[DEBUG MODE] Logs: ~/.golazo/golazo_debug.log"
+		message = "[DEBUG MODE] Logs: " + data.DebugLogPath()
 	case constants.StatusBannerNewVersion:
 		message = "New Version Available! Run 'golazo --update'"
 	case constants.StatusBannerDev:


### PR DESCRIPTION
## Summary
The `--debug` banner and `--debug` flag help hardcoded `~/.golazo/golazo_debug.log`, which is wrong on Linux where `data.ConfigDir()` already resolves to `~/.config/golazo` per XDG. Banner and help now use a new platform-aware `data.DebugLogPath()` helper.

## Updates
- Added pure `data.DebugLogPath()` helper (no FS side effects) with unit tests for Linux XDG, Linux default, and non-Linux branches.
- Wired the helper into the debug-mode banner, the `--debug` flag help, and the stale `initLogger` doc comment; added a `renderStatusBanner` test asserting the banner contains the helper's output.
- Logged a Fixed entry under `Unreleased` in `CHANGELOG.md`.