### PR TITLE
fix[cmd/update]: skip --update when already on latest version or dev build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **Update Noop** - `golazo --update` now skips the Homebrew/install-script call when the running binary is already on the latest GitHub release (or is a dev build), printing an informative message instead of reinstalling. Network failures while checking the latest version still fall through to today's install behavior.
 - **Debug Log Hint** - The `--debug` banner and `--debug` flag help now display the platform-correct log path (`~/.config/golazo/golazo_debug.log` on Linux per XDG, `~/.golazo/golazo_debug.log` on macOS/Windows) instead of a hardcoded macOS path.
 - **World Cup Hints** - Removed a redundant tab hint above the groups list so each sub-view shows a single, accurate help line.
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -74,7 +74,18 @@ var rootCmd = &cobra.Command{
 }
 
 // runUpdate executes the appropriate update method based on installation detection.
+// It first checks whether the running binary is already on the latest release (or
+// is a dev build) and short-circuits with an informative message in that case.
 func runUpdate() {
+	latest, fetchErr := data.CheckLatestVersion()
+	proceed, message := decideUpdate(Version, latest, fetchErr)
+	if message != "" {
+		fmt.Println(message)
+	}
+	if !proceed {
+		return
+	}
+
 	installMethod := detectInstallationMethod()
 
 	switch installMethod {
@@ -95,6 +106,30 @@ func runUpdate() {
 			os.Exit(1)
 		}
 	}
+}
+
+// decideUpdate returns whether runUpdate should shell out to the installer, plus
+// a user-facing message to print first. It is pure (no I/O) so the policy is unit
+// testable without invoking brew or the install script.
+//
+// Policy:
+//   - Dev builds short-circuit (cannot meaningfully self-update).
+//   - On fetch failure we proceed: the user explicitly asked to update, so a
+//     network flake shouldn't block them — fall back to today's behavior.
+//   - If the current version is not older than latest (equal, or local ahead of
+//     the published release), short-circuit with an informative message.
+//   - Otherwise proceed.
+func decideUpdate(current, latest string, fetchErr error) (proceed bool, message string) {
+	if current == "dev" {
+		return false, "Running a dev build; skipping update."
+	}
+	if fetchErr != nil || latest == "" {
+		return true, ""
+	}
+	if version.IsOlder(current, latest) {
+		return true, ""
+	}
+	return false, fmt.Sprintf("Already on the latest version (%s).", current)
 }
 
 // runBrewUpdate attempts to update golazo via Homebrew.

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,94 @@
+package cmd
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestDecideUpdate(t *testing.T) {
+	tests := []struct {
+		name            string
+		current         string
+		latest          string
+		fetchErr        error
+		wantProceed     bool
+		wantMsgContains string
+	}{
+		{
+			name:            "dev build short-circuits regardless of latest",
+			current:         "dev",
+			latest:          "v1.2.3",
+			fetchErr:        nil,
+			wantProceed:     false,
+			wantMsgContains: "dev build",
+		},
+		{
+			name:            "dev build short-circuits even on fetch error",
+			current:         "dev",
+			latest:          "",
+			fetchErr:        errors.New("network down"),
+			wantProceed:     false,
+			wantMsgContains: "dev build",
+		},
+		{
+			name:            "current equals latest -> noop with friendly message",
+			current:         "v1.2.3",
+			latest:          "v1.2.3",
+			fetchErr:        nil,
+			wantProceed:     false,
+			wantMsgContains: "v1.2.3",
+		},
+		{
+			name:            "current older than latest -> proceed silently",
+			current:         "v1.2.2",
+			latest:          "v1.2.3",
+			fetchErr:        nil,
+			wantProceed:     true,
+			wantMsgContains: "",
+		},
+		{
+			name:            "current newer than latest -> noop (don't downgrade)",
+			current:         "v1.3.0",
+			latest:          "v1.2.3",
+			fetchErr:        nil,
+			wantProceed:     false,
+			wantMsgContains: "v1.3.0",
+		},
+		{
+			name:            "fetch error on non-dev -> proceed (network flake shouldn't block)",
+			current:         "v1.2.2",
+			latest:          "",
+			fetchErr:        errors.New("network down"),
+			wantProceed:     true,
+			wantMsgContains: "",
+		},
+		{
+			name:            "empty latest with no error -> proceed (treat as unknown)",
+			current:         "v1.2.2",
+			latest:          "",
+			fetchErr:        nil,
+			wantProceed:     true,
+			wantMsgContains: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotProceed, gotMsg := decideUpdate(tt.current, tt.latest, tt.fetchErr)
+			if gotProceed != tt.wantProceed {
+				t.Errorf("decideUpdate(%q, %q, %v) proceed = %v, want %v",
+					tt.current, tt.latest, tt.fetchErr, gotProceed, tt.wantProceed)
+			}
+			if tt.wantMsgContains == "" {
+				if gotMsg != "" {
+					t.Errorf("decideUpdate(%q, %q, %v) message = %q, want empty",
+						tt.current, tt.latest, tt.fetchErr, gotMsg)
+				}
+			} else if !strings.Contains(gotMsg, tt.wantMsgContains) {
+				t.Errorf("decideUpdate(%q, %q, %v) message = %q, want it to contain %q",
+					tt.current, tt.latest, tt.fetchErr, gotMsg, tt.wantMsgContains)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Resolves https://github.com/0xjuanma/golazo/issues/147. `golazo --update` shelled out to brew/install-script unconditionally, even when the running binary already matched the latest GitHub release. It now compares the embedded build version to the latest release first and noops with an informative message when there is nothing to do.

## Updates
- Added a pure `decideUpdate(current, latest, fetchErr)` helper in `cmd/root.go` that short-circuits on dev builds and when the current version is not older than the latest release; network failures still fall through to today's install behavior so a flake can't block an explicit `--update`.
- Wired the decision into `runUpdate` before the brew/script dispatch and added a 7-case table-driven test in the new `cmd/root_test.go` (first test file in the `cmd/` package).