### PR TITLE
fix[ui/worldcup]: render teams as 3-letter code with flag across all views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
-- **World Cup Team Labels** - All World Cup views (groups list, group detail table, group grid, bracket matchups, winner arrows, champion line, upcoming matches) now render teams consistently as `<flag emoji> <3-letter code>` (e.g. `🇦🇷 ARG`). Previously the table and bracket used full country names while the grid and list used 3-letter codes, and teams missing FotMob's `shortName` fell back to a naive 3-character truncation that produced wrong codes (e.g. `Net` for Netherlands); a local World Cup name-to-code override map now resolves these correctly.
+- **World Cup Team Labels** - All World Cup views now render teams as `<flag> <3-letter code>` (e.g. `🇦🇷 ARG`), with a local name-to-code map for teams missing a `shortName` from FotMob.
 - **Update Noop** - `golazo --update` now skips the Homebrew/install-script call when the running binary is already on the latest GitHub release (or is a dev build), printing an informative message instead of reinstalling. Network failures while checking the latest version still fall through to today's install behavior.
 - **Debug Log Hint** - The `--debug` banner and `--debug` flag help now display the platform-correct log path (`~/.config/golazo/golazo_debug.log` on Linux per XDG, `~/.golazo/golazo_debug.log` on macOS/Windows) instead of a hardcoded macOS path.
 - **World Cup Hints** - Removed a redundant tab hint above the groups list so each sub-view shows a single, accurate help line.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **World Cup Team Labels** - All World Cup views (groups list, group detail table, group grid, bracket matchups, winner arrows, champion line, upcoming matches) now render teams consistently as `<flag emoji> <3-letter code>` (e.g. `🇦🇷 ARG`). Previously the table and bracket used full country names while the grid and list used 3-letter codes, and teams missing FotMob's `shortName` fell back to a naive 3-character truncation that produced wrong codes (e.g. `Net` for Netherlands); a local World Cup name-to-code override map now resolves these correctly.
 - **Update Noop** - `golazo --update` now skips the Homebrew/install-script call when the running binary is already on the latest GitHub release (or is a dev build), printing an informative message instead of reinstalling. Network failures while checking the latest version still fall through to today's install behavior.
 - **Debug Log Hint** - The `--debug` banner and `--debug` flag help now display the platform-correct log path (`~/.config/golazo/golazo_debug.log` on Linux per XDG, `~/.golazo/golazo_debug.log` on macOS/Windows) instead of a hardcoded macOS path.
 - **World Cup Hints** - Removed a redundant tab hint above the groups list so each sub-view shows a single, accurate help line.

--- a/internal/ui/worldcup/bracket.go
+++ b/internal/ui/worldcup/bracket.go
@@ -77,8 +77,7 @@ func RenderBracket(width, height int, wcData *api.WorldCupData, scrollOffset int
 	// Champion card
 	if wcData.Champion != nil {
 		lines = append(lines, "")
-		emoji := FlagEmoji(wcData.Champion.ShortName)
-		champ := ChampionStyle.Render(fmt.Sprintf("  🏆  Champion: %s %s", emoji, wcData.Champion.Name))
+		champ := ChampionStyle.Render(fmt.Sprintf("  🏆  Champion: %s", TeamLabel(*wcData.Champion)))
 		lines = append(lines, champ)
 	}
 
@@ -168,21 +167,16 @@ func renderBracketRound(round api.WCKnockoutRound, width int) []string {
 	return lines
 }
 
-// nextRoundTeamName returns the winner's short name for a matchup.
+// nextRoundTeamName returns the winner's label (flag + 3-letter code) for a
+// matchup, or "TBD" when the matchup is unresolved.
 func nextRoundTeamName(mu api.WCMatchup) string {
 	if mu.WinnerID == nil {
 		return "TBD"
 	}
 	if *mu.WinnerID == mu.HomeTeamID {
-		if mu.HomeShort != "" {
-			return mu.HomeShort
-		}
-		return mu.HomeTeam
+		return MatchupTeamLabel(mu.HomeShort, mu.HomeTeam, mu.TBDHome)
 	}
-	if mu.AwayShort != "" {
-		return mu.AwayShort
-	}
-	return mu.AwayTeam
+	return MatchupTeamLabel(mu.AwayShort, mu.AwayTeam, mu.TBDAway)
 }
 
 // renderBracketLine renders a single matchup line with flag emojis.
@@ -191,21 +185,11 @@ func renderBracketLine(mu api.WCMatchup) string {
 }
 
 func renderBracketLineRaw(mu api.WCMatchup, showArrow bool) string {
-	const nameW = 14
+	const nameW = 8 // "<emoji> CODE" → typically 6 visual cells; small slack
 	const scoreW = 7
 
-	home := teamDisplay(mu.HomeShort, mu.HomeTeam, mu.TBDHome)
-	away := teamDisplay(mu.AwayShort, mu.AwayTeam, mu.TBDAway)
-
-	homeEmoji := FlagEmoji(mu.HomeShort)
-	awayEmoji := FlagEmoji(mu.AwayShort)
-
-	if len(home) > nameW {
-		home = home[:nameW]
-	}
-	if len(away) > nameW {
-		away = away[:nameW]
-	}
+	home := MatchupTeamLabel(mu.HomeShort, mu.HomeTeam, mu.TBDHome)
+	away := MatchupTeamLabel(mu.AwayShort, mu.AwayTeam, mu.TBDAway)
 
 	homeIsWinner := mu.WinnerID != nil && *mu.WinnerID == mu.HomeTeamID
 	awayIsWinner := mu.WinnerID != nil && *mu.WinnerID == mu.AwayTeamID
@@ -230,38 +214,23 @@ func renderBracketLineRaw(mu api.WCMatchup, showArrow bool) string {
 	}
 	scoreStr = lipgloss.NewStyle().Width(scoreW).Align(lipgloss.Center).Render(scoreStr)
 
-	homeFlag := lipgloss.NewStyle().Width(3).Render(homeEmoji)
-	awayFlag := lipgloss.NewStyle().Width(3).Render(awayEmoji)
-
 	if mu.WinnerID == nil || !showArrow {
-		return MatchLineStyle.Render(fmt.Sprintf("  %s%s  %s  %s%s", homeFlag, homeStr, scoreStr, awayFlag, awayStr))
+		return MatchLineStyle.Render(fmt.Sprintf("  %s  %s  %s", homeStr, scoreStr, awayStr))
 	}
 
-	winnerShort := mu.HomeShort
+	winnerLabel := MatchupTeamLabel(mu.HomeShort, mu.HomeTeam, mu.TBDHome)
 	if *mu.WinnerID == mu.AwayTeamID {
-		winnerShort = mu.AwayShort
+		winnerLabel = MatchupTeamLabel(mu.AwayShort, mu.AwayTeam, mu.TBDAway)
 	}
 	penStr := ""
 	if mu.IsPenalties {
 		penStr = " " + PenStyle.Render("(p)")
 	}
-	emoji := FlagEmoji(winnerShort)
-	winner := WinnerStyle.Render(winnerShort) + penStr
+	winner := WinnerStyle.Render(winnerLabel) + penStr
 	arrow := MatchLineStyle.Render("  ──► ")
 
-	return fmt.Sprintf("  %s%s  %s  %s%s%s%s %s",
-		homeFlag, homeStr, scoreStr, awayFlag, awayStr, arrow, emoji, winner)
-}
-
-// teamDisplay returns the display name for a team slot.
-func teamDisplay(short, full string, tbd bool) string {
-	if tbd {
-		return "TBD"
-	}
-	if short != "" {
-		return short
-	}
-	return full
+	return fmt.Sprintf("  %s  %s  %s%s%s",
+		homeStr, scoreStr, awayStr, arrow, winner)
 }
 
 func max(a, b int) int {

--- a/internal/ui/worldcup/groups.go
+++ b/internal/ui/worldcup/groups.go
@@ -22,19 +22,7 @@ func (i WCGroupItem) Title() string       { return i.Group.Name }
 func (i WCGroupItem) Description() string {
 	parts := make([]string, 0, len(i.Group.Teams))
 	for _, t := range i.Group.Teams {
-		name := t.Team.ShortName
-		if name == "" {
-			name = t.Team.Name
-		}
-		if len(name) > 3 {
-			name = name[:3]
-		}
-		emoji := FlagEmoji(t.Team.ShortName)
-		if emoji != "" {
-			parts = append(parts, fmt.Sprintf("%s %s %d", emoji, name, t.Points))
-		} else {
-			parts = append(parts, fmt.Sprintf("%s %d", name, t.Points))
-		}
+		parts = append(parts, fmt.Sprintf("%s %d", TeamLabel(t.Team), t.Points))
 	}
 	return strings.Join(parts, "  ")
 }
@@ -177,14 +165,17 @@ func renderGroupStandingsTable(g api.WCGroup, width int) string {
 		return LoadingStyle.Render("No standings data")
 	}
 
-	// Col widths: # (3) + 2sp + Team (nameW, includes 3-wide flag prefix) +
-	// P(4)+W(4)+D(4)+L(4)+GF(4)+GA(4)+GD(5)+Pts(4) = nameW + 42
+	// Col widths: # (3) + 2sp + Team (nameW, includes 3-wide flag prefix +
+	// space + 3-letter code) + P(4)+W(4)+D(4)+L(4)+GF(4)+GA(4)+GD(5)+Pts(4)
+	// = nameW + 42. Team labels are now always "<flag> <CODE>" so a fixed
+	// 7-wide column is enough; widen up to 10 on roomier terminals for
+	// breathing space.
 	nameW := width - 42
-	if nameW < 11 {
-		nameW = 11
+	if nameW < 7 {
+		nameW = 7
 	}
-	if nameW > 23 {
-		nameW = 23
+	if nameW > 10 {
+		nameW = 10
 	}
 
 	hdr := lipgloss.JoinHorizontal(lipgloss.Top,
@@ -206,8 +197,7 @@ func renderGroupStandingsTable(g api.WCGroup, width int) string {
 
 	lines := []string{hdr, sep}
 	for i, t := range g.Teams {
-		emoji := FlagEmoji(t.Team.ShortName)
-		teamLabel := teamNameWithFlag(emoji, t.Team.Name, nameW)
+		teamLabel := lipgloss.PlaceHorizontal(nameW, lipgloss.Left, TeamLabel(t.Team))
 
 		var teamStyle, ptsStyle lipgloss.Style
 		switch {
@@ -243,48 +233,11 @@ func renderGroupStandingsTable(g api.WCGroup, width int) string {
 	return strings.Join(lines, "\n")
 }
 
-// teamNameWithFlag returns "<emoji> <name>" padded to colW visual cells.
-// Emoji takes a fixed 3-cell prefix slot so rows align even when some teams
-// lack a flag mapping. The name is truncated with an ellipsis when it would
-// overflow the column.
-func teamNameWithFlag(emoji, name string, colW int) string {
-	const flagSlot = 3 // visual cells reserved for emoji + trailing space
-	nameSpace := colW - flagSlot
-	if nameSpace < 1 {
-		nameSpace = 1
-	}
-	if lipgloss.Width(name) > nameSpace {
-		// Truncate by rune to avoid splitting multi-byte chars.
-		runes := []rune(name)
-		for nameSpace > 0 && lipgloss.Width(string(runes[:nameSpace])+"…") > nameSpace {
-			nameSpace--
-		}
-		if nameSpace > 0 {
-			name = string(runes[:nameSpace]) + "…"
-		} else {
-			name = "…"
-		}
-	}
-	prefix := emoji
-	if emoji == "" {
-		prefix = "  "
-	} else {
-		prefix = emoji + " "
-	}
-	combined := prefix + name
-	return lipgloss.PlaceHorizontal(colW, lipgloss.Left, combined)
-}
-
 // renderQualificationRow renders a compact one-line summary of qualified teams.
 func renderQualificationRow(g api.WCGroup, width int) string {
 	var parts []string
 	for i, t := range g.Teams {
-		name := t.Team.Name
-		emoji := FlagEmoji(t.Team.ShortName)
-		display := name
-		if emoji != "" {
-			display = emoji + " " + name
-		}
+		display := TeamLabel(t.Team)
 		switch {
 		case i < 2:
 			parts = append(parts, QualifiedStyle.Render("✓ "+display))
@@ -369,15 +322,6 @@ func renderGroupGridCell(g api.WCGroup, width int) string {
 	title := GridGroupHeaderStyle.Render(g.Name)
 	lines := []string{title}
 	for i, t := range g.Teams {
-		short := t.Team.ShortName
-		if short == "" {
-			short = t.Team.Name
-		}
-		if len(short) > 3 {
-			short = short[:3]
-		}
-		emoji := FlagEmoji(t.Team.ShortName)
-
 		pts := fmt.Sprintf("%2d", t.Points)
 
 		var ts lipgloss.Style
@@ -390,15 +334,10 @@ func renderGroupGridCell(g api.WCGroup, width int) string {
 			ts = GridTeamDimStyle
 		}
 
-		// Render emoji+name as a single styled chunk to avoid terminals
+		// Render emoji+code as a single styled chunk to avoid terminals
 		// dropping the regional-indicator pair when sandwiched between
 		// neighboring ANSI escape sequences.
-		var label string
-		if emoji != "" {
-			label = ts.Render(fmt.Sprintf("%s %-3s", emoji, short))
-		} else {
-			label = ts.Render(fmt.Sprintf("   %-3s", short))
-		}
+		label := ts.Render(TeamLabel(t.Team))
 		line := "  " + label + " " + ts.Render(pts)
 		lines = append(lines, line)
 	}

--- a/internal/ui/worldcup/groups_test.go
+++ b/internal/ui/worldcup/groups_test.go
@@ -52,17 +52,20 @@ func TestRenderGroupStandingsTable_EmojiAdjacentToName(t *testing.T) {
 	fraFlag := FlagEmoji("FRA")
 	braFlag := FlagEmoji("BRA")
 
+	// Standings table now renders the consistent "<flag> CODE" label used by
+	// every World Cup view.
 	for _, expect := range []string{
-		argFlag + " Argentina",
-		fraFlag + " France",
-		braFlag + " Brazil",
+		argFlag + " ARG",
+		fraFlag + " FRA",
+		braFlag + " BRA",
 	} {
 		if !strings.Contains(table, expect) {
 			t.Errorf("expected standings table to contain literal %q, got:\n%s", expect, table)
 		}
 	}
 
-	if !strings.Contains(table, "Nowhereland") {
-		t.Errorf("expected unmapped team name in table, got:\n%s", table)
+	// Unmapped short code still appears as the bare code (no flag).
+	if !strings.Contains(table, "ZZZ") {
+		t.Errorf("expected unmapped short code ZZZ in table, got:\n%s", table)
 	}
 }

--- a/internal/ui/worldcup/team_label.go
+++ b/internal/ui/worldcup/team_label.go
@@ -40,19 +40,25 @@ func MatchupTeamLabel(short, full string, tbd bool) string {
 }
 
 // teamCode resolves a team to its canonical 3-letter code using the chain
-// described on TeamLabel.
+// described on TeamLabel. The returned code is always truncated to at most
+// three characters so every WC view renders teams in the same column width.
 func teamCode(short, full string) string {
 	if c := strings.ToUpper(strings.TrimSpace(short)); c != "" {
-		return c
+		return capCode(c)
 	}
 	if c, ok := wcNameToCode[strings.ToLower(strings.TrimSpace(full))]; ok {
-		return c
+		return capCode(c)
 	}
 	stripped := strings.ToUpper(strings.ReplaceAll(full, " ", ""))
-	if len(stripped) > 3 {
-		stripped = stripped[:3]
+	return capCode(stripped)
+}
+
+// capCode enforces the 3-letter cap shared by every code-resolution branch.
+func capCode(c string) string {
+	if len(c) > 3 {
+		return c[:3]
 	}
-	return stripped
+	return c
 }
 
 // labelWithFlag renders "<emoji> <CODE>", padding the emoji slot with two

--- a/internal/ui/worldcup/team_label.go
+++ b/internal/ui/worldcup/team_label.go
@@ -1,0 +1,193 @@
+package worldcup
+
+import (
+	"strings"
+
+	"github.com/0xjuanma/golazo/internal/api"
+)
+
+// TeamLabel returns the consistent World Cup display label for a team:
+// "<flag-emoji> <CODE>", where <CODE> is the FIFA 3-letter abbreviation.
+//
+// The code resolution chain is:
+//  1. team.ShortName, if non-empty (already a 3-letter code from FotMob).
+//  2. A WC-local Name → code override map for known mismatches where FotMob
+//     ships the full English name without a short code (e.g. "Netherlands" → "NED").
+//  3. A deterministic fallback: uppercase the first 3 letters of the name with
+//     spaces stripped (e.g. "Cape Verde" → "CAP"). This is never ideal but
+//     keeps every cell aligned even when we receive an unknown country.
+//
+// When no flag emoji is registered for the resolved code, the emoji slot is
+// padded with two spaces so that columns stay aligned across rows.
+func TeamLabel(t api.Team) string {
+	code := teamCode(t.ShortName, t.Name)
+	return labelWithFlag(code)
+}
+
+// MatchupTeamLabel is the matchup-shape variant: bracket matchups carry
+// (short, full, tbd) as separate fields on api.WCMatchup rather than an
+// api.Team value. It applies the same code resolution chain as TeamLabel
+// and returns "TBD" for unresolved bracket slots.
+func MatchupTeamLabel(short, full string, tbd bool) string {
+	if tbd {
+		return "TBD"
+	}
+	if short == "" && full == "" {
+		return "TBD"
+	}
+	code := teamCode(short, full)
+	return labelWithFlag(code)
+}
+
+// teamCode resolves a team to its canonical 3-letter code using the chain
+// described on TeamLabel.
+func teamCode(short, full string) string {
+	if c := strings.ToUpper(strings.TrimSpace(short)); c != "" {
+		return c
+	}
+	if c, ok := wcNameToCode[strings.ToLower(strings.TrimSpace(full))]; ok {
+		return c
+	}
+	stripped := strings.ToUpper(strings.ReplaceAll(full, " ", ""))
+	if len(stripped) > 3 {
+		stripped = stripped[:3]
+	}
+	return stripped
+}
+
+// labelWithFlag renders "<emoji> <CODE>", padding the emoji slot with two
+// spaces when no flag is registered so columns line up across rows.
+func labelWithFlag(code string) string {
+	if code == "" {
+		return "   " // 3-cell placeholder consistent with emoji + space slot
+	}
+	if emoji := FlagEmoji(code); emoji != "" {
+		return emoji + " " + code
+	}
+	return "   " + code
+}
+
+// wcNameToCode covers WC teams whose FotMob payloads sometimes ship a full
+// English name without a populated shortName. Keep keys lowercase for the
+// case-insensitive lookup in teamCode. Coverage tracks flagEmojis (WC 2022
+// participants + likely 2026 qualifiers) so a new entry there should add a
+// matching entry here when the name → code mapping is non-obvious.
+var wcNameToCode = map[string]string{
+	// Names that don't naive-truncate correctly.
+	"netherlands":       "NED",
+	"holland":           "NED",
+	"saudi arabia":      "KSA",
+	"south korea":       "KOR",
+	"korea republic":    "KOR",
+	"republic of korea": "KOR",
+	"north korea":       "PRK",
+	"costa rica":        "CRC",
+	"switzerland":       "SUI",
+	"croatia":           "CRO",
+	"serbia":            "SRB",
+	"poland":            "POL",
+	"portugal":          "POR",
+	"germany":           "GER",
+	"denmark":           "DEN",
+	"belgium":           "BEL",
+	"morocco":           "MAR",
+	"senegal":           "SEN",
+	"cameroon":          "CMR",
+	"ghana":             "GHA",
+	"uruguay":           "URU",
+	"australia":         "AUS",
+	"ecuador":           "ECU",
+	"qatar":             "QAT",
+	"iran":              "IRN",
+	"ir iran":           "IRN",
+	"wales":             "WAL",
+	"england":           "ENG",
+	"scotland":          "SCO",
+	"northern ireland":  "NIR",
+	"czech republic":    "CZE",
+	"czechia":           "CZE",
+	"slovakia":          "SVK",
+	"slovenia":          "SLO",
+	"romania":           "ROU",
+	"hungary":           "HUN",
+	"austria":           "AUT",
+	"ukraine":           "UKR",
+	"turkey":            "TUR",
+	"türkiye":           "TUR",
+	"greece":            "GRE",
+	"ireland":           "IRL",
+	"republic of ireland": "IRL",
+	"iceland":           "ISL",
+	"norway":            "NOR",
+	"sweden":            "SWE",
+	"finland":           "FIN",
+	"bosnia & herzegovina": "BIH",
+	"bosnia and herzegovina": "BIH",
+	"north macedonia":   "MKD",
+	"montenegro":        "MNE",
+	"albania":           "ALB",
+	"kosovo":            "KSV",
+	"georgia":           "GEO",
+	"azerbaijan":        "AZE",
+	"armenia":           "ARM",
+	// Americas.
+	"united states":     "USA",
+	"usa":               "USA",
+	"mexico":            "MEX",
+	"canada":            "CAN",
+	"argentina":         "ARG",
+	"brazil":            "BRA",
+	"chile":             "CHI",
+	"peru":              "PER",
+	"colombia":          "COL",
+	"venezuela":         "VEN",
+	"paraguay":          "PAR",
+	"bolivia":           "BOL",
+	"honduras":          "HON",
+	"panama":            "PAN",
+	"jamaica":           "JAM",
+	"trinidad and tobago": "TRI",
+	"cuba":              "CUB",
+	// Africa.
+	"nigeria":           "NGA",
+	"ivory coast":       "CIV",
+	"côte d'ivoire":     "CIV",
+	"cote d'ivoire":     "CIV",
+	"algeria":           "ALG",
+	"egypt":             "EGY",
+	"mali":              "MLI",
+	"guinea-bissau":     "GNB",
+	"guinea bissau":     "GNB",
+	"south africa":      "RSA",
+	"zimbabwe":          "ZIM",
+	"dr congo":          "COD",
+	"congo dr":          "COD",
+	"tanzania":          "TAN",
+	"uganda":            "UGA",
+	"kenya":             "KEN",
+	// Asia/Oceania.
+	"japan":             "JPN",
+	"china":             "CHN",
+	"china pr":          "CHN",
+	"india":             "IND",
+	"indonesia":         "IDN",
+	"philippines":       "PHI",
+	"thailand":          "THA",
+	"vietnam":           "VIE",
+	"malaysia":          "MYS",
+	"iraq":              "IRQ",
+	"syria":             "SYR",
+	"jordan":            "JOR",
+	"palestine":         "PAL",
+	"lebanon":           "LIB",
+	"united arab emirates": "UAE",
+	"oman":              "OMA",
+	"bahrain":           "BHR",
+	"kuwait":            "KUW",
+	"new zealand":       "NZL",
+	// Europe big-five and others not already truncating right.
+	"spain":             "ESP",
+	"france":            "FRA",
+	"italy":             "ITA",
+	"tunisia":           "TUN",
+}

--- a/internal/ui/worldcup/team_label_test.go
+++ b/internal/ui/worldcup/team_label_test.go
@@ -10,8 +10,9 @@ import (
 func TestTeamLabel(t *testing.T) {
 	argFlag := FlagEmoji("ARG")
 	nedFlag := FlagEmoji("NED")
-	if argFlag == "" || nedFlag == "" {
-		t.Fatal("expected ARG/NED to have flag emojis registered")
+	ausFlag := FlagEmoji("AUS")
+	if argFlag == "" || nedFlag == "" || ausFlag == "" {
+		t.Fatal("expected ARG/NED/AUS to have flag emojis registered")
 	}
 
 	tests := []struct {
@@ -53,6 +54,11 @@ func TestTeamLabel(t *testing.T) {
 			name: "name override is case-insensitive",
 			team: api.Team{Name: "NETHERLANDS"},
 			want: nedFlag + " NED",
+		},
+		{
+			name: "short name longer than 3 chars is truncated",
+			team: api.Team{Name: "Australia", ShortName: "AUST"},
+			want: ausFlag + " AUS", // "AUST" → "AUS" → flag resolves
 		},
 	}
 

--- a/internal/ui/worldcup/team_label_test.go
+++ b/internal/ui/worldcup/team_label_test.go
@@ -1,0 +1,112 @@
+package worldcup
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/0xjuanma/golazo/internal/api"
+)
+
+func TestTeamLabel(t *testing.T) {
+	argFlag := FlagEmoji("ARG")
+	nedFlag := FlagEmoji("NED")
+	if argFlag == "" || nedFlag == "" {
+		t.Fatal("expected ARG/NED to have flag emojis registered")
+	}
+
+	tests := []struct {
+		name string
+		team api.Team
+		want string
+	}{
+		{
+			name: "short name present takes precedence",
+			team: api.Team{Name: "Argentina", ShortName: "ARG"},
+			want: argFlag + " ARG",
+		},
+		{
+			name: "short name empty falls back to name override map",
+			team: api.Team{Name: "Netherlands", ShortName: ""},
+			want: nedFlag + " NED",
+		},
+		{
+			name: "short name empty + unknown name truncates to 3 letters",
+			team: api.Team{Name: "Nowhereland", ShortName: ""},
+			want: "   NOW",
+		},
+		{
+			name: "short name lowercase is normalized",
+			team: api.Team{Name: "Argentina", ShortName: "arg"},
+			want: argFlag + " ARG",
+		},
+		{
+			name: "unknown short code keeps the code but no flag",
+			team: api.Team{Name: "Nowhereland", ShortName: "ZZZ"},
+			want: "   ZZZ",
+		},
+		{
+			name: "short name with whitespace is trimmed",
+			team: api.Team{Name: "Argentina", ShortName: "  ARG  "},
+			want: argFlag + " ARG",
+		},
+		{
+			name: "name override is case-insensitive",
+			team: api.Team{Name: "NETHERLANDS"},
+			want: nedFlag + " NED",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := TeamLabel(tt.team); got != tt.want {
+				t.Errorf("TeamLabel(%+v) = %q, want %q", tt.team, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatchupTeamLabel(t *testing.T) {
+	argFlag := FlagEmoji("ARG")
+	nedFlag := FlagEmoji("NED")
+
+	tests := []struct {
+		name  string
+		short string
+		full  string
+		tbd   bool
+		want  string
+	}{
+		{name: "tbd returns TBD", tbd: true, want: "TBD"},
+		{name: "tbd takes precedence over short", short: "ARG", full: "Argentina", tbd: true, want: "TBD"},
+		{name: "empty short and full returns TBD", want: "TBD"},
+		{name: "short present", short: "ARG", full: "Argentina", want: argFlag + " ARG"},
+		{name: "short empty, name in override", full: "Netherlands", want: nedFlag + " NED"},
+		{name: "short empty, unknown name truncates", full: "Nowhereland", want: "   NOW"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := MatchupTeamLabel(tt.short, tt.full, tt.tbd); got != tt.want {
+				t.Errorf("MatchupTeamLabel(%q, %q, %v) = %q, want %q",
+					tt.short, tt.full, tt.tbd, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTeamLabel_AlwaysContainsCode(t *testing.T) {
+	// Every label must include the resolved code so callers don't need to
+	// re-derive it (e.g. for column-width estimation).
+	cases := []api.Team{
+		{Name: "Argentina", ShortName: "ARG"},
+		{Name: "Netherlands"},
+		{Name: "Nowhereland"},
+	}
+	for _, c := range cases {
+		label := TeamLabel(c)
+		code := teamCode(c.ShortName, c.Name)
+		if !strings.Contains(label, code) {
+			t.Errorf("TeamLabel(%+v) = %q must contain code %q", c, label, code)
+		}
+	}
+}

--- a/internal/ui/worldcup/upcoming.go
+++ b/internal/ui/worldcup/upcoming.go
@@ -83,8 +83,8 @@ func renderWCUpcomingMatches(matches []api.Match) string {
 		}
 
 		timeStr := timeStyle.Render(local.Format("15:04"))
-		home := teamStyle.Render(wcUpcomingTeamLabel(m.HomeTeam))
-		away := teamStyle.Render(wcUpcomingTeamLabel(m.AwayTeam))
+		home := teamStyle.Render(TeamLabel(m.HomeTeam))
+		away := teamStyle.Render(TeamLabel(m.AwayTeam))
 		line := fmt.Sprintf("  %s  %s %s %s", timeStr, home, vsStyle.Render("vs"), away)
 
 		if m.Round != "" {
@@ -94,26 +94,6 @@ func renderWCUpcomingMatches(matches []api.Match) string {
 	}
 
 	return strings.Join(lines, "\n")
-}
-
-// wcShortName returns the team's short name when available, falling back to
-// the full name. Used to keep the upcoming list compact.
-func wcShortName(t api.Team) string {
-	if t.ShortName != "" {
-		return t.ShortName
-	}
-	return t.Name
-}
-
-// wcUpcomingTeamLabel prefixes the team's short name with its flag emoji when
-// one is available, producing e.g. "🇦🇷 ARG". Teams without a flag mapping
-// fall back to the short name alone so the layout stays consistent.
-func wcUpcomingTeamLabel(t api.Team) string {
-	name := wcShortName(t)
-	if emoji := FlagEmoji(t.ShortName); emoji != "" {
-		return emoji + " " + name
-	}
-	return name
 }
 
 // upcomingFormatDateHeader is exposed for tests to assert the date header


### PR DESCRIPTION
## Summary
World Cup views rendered teams inconsistently — the group detail table and bracket used full country names (e.g. `🇦🇷 Argentina`), the grid/list used 3-letter codes (e.g. `🇦🇷 ARG`), and teams missing FotMob's `shortName` fell back to a naive `Name[:3]` that produced wrong codes (e.g. `Net` for Netherlands). All in-scope views now render `<flag emoji> <3-letter code>` from a single helper, with a World-Cup-local name → code override map covering the known mismatches.

## Updates
- Added `TeamLabel` and `MatchupTeamLabel` helpers (plus a WC-local name → code override map) in a new `internal/ui/worldcup/team_label.go`, and refactored all 9 render sites across `groups.go`, `bracket.go`, and `upcoming.go` to use them; deleted the now-dead `teamDisplay`, `teamNameWithFlag`, `wcShortName`, and `wcUpcomingTeamLabel`.
- Tightened the column widths that were sized for full names (standings `nameW` clamp `[11,23]` → `[7,10]`, bracket `nameW` 14 → 8) so the new compact labels don't render with trailing whitespace.
- Added a 16-case `team_label_test.go` table covering the resolution chain (ShortName → override map → uppercase truncate) and updated the existing standings assertion to expect the new label format; `flags_emoji.go`, the FotMob parser, and `api` types are untouched.