### PR TITLE
feat[cmd/cli]: add agentic cli mode with json subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Agentic CLI Mode** - New JSON subcommands (`golazo live`, `finished`, `match <id>`, `leagues`) that emit structured output to stdout for agents and scripts. Includes typed error codes, documented exit codes, `degraded` flag for partial multi-day failures, deterministic sort, and `GOLAZO_AGENT` / `GOLAZO_OFFLINE` env guardrails. TUI behavior is unchanged. See [docs/CLI.md](docs/CLI.md).
+- **Agentic CLI Mode** - Golazo is now usable by agentic dev tools (Claude Code, Codex, etc). Adds JSON subcommands (`live`, `finished`, `match`, `leagues`, `capabilities`) with a stable envelope, typed error codes and self-describing contract. TUI behavior is unchanged. See [docs/CLI.md](docs/CLI.md).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Agentic CLI Mode** - New JSON subcommands (`golazo live`, `finished`, `match <id>`, `leagues`) that emit structured output to stdout for agents and scripts. Includes typed error codes, documented exit codes, `degraded` flag for partial multi-day failures, deterministic sort, and `GOLAZO_AGENT` / `GOLAZO_OFFLINE` env guardrails. TUI behavior is unchanged. See [docs/CLI.md](docs/CLI.md).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
 
 A minimalist terminal user interface (TUI) for following football (soccer) matches in real-time. Get live match updates, finished match statistics, and minute-by-minute events directly in your terminal.
 
+Golazo also ships a JSON CLI for agents and scripts (`golazo live`, `finished`, `match`, `leagues`, `capabilities`) — see **[CLI / Agent Mode](docs/CLI.md)**.
+
 Golazo was created for those moments when you can't stream or watch matches live. It gives you a handy, non-intrusive, and minimalist way to keep up with your favourite football leagues.
 
 *Perfect for developers and terminal enthusiasts who want match updates without leaving their workflow.*
@@ -44,6 +46,7 @@ Golazo was created for those moments when you can't stream or watch matches live
 - **Official Highlights & Replay Links**: Clickable links for official highlights and instant goal replays
 - **Goal Notifications**: Desktop notifications for goals as they happen
 - **65+ Leagues**: Organized by region (Europe, Americas, Global) with tab navigation in Settings
+- **JSON CLI for agents**: `golazo live`, `finished`, `match`, `leagues`, `capabilities` — structured output, typed error codes, exit code map. See [docs/CLI.md](docs/CLI.md).
 
 ## Installation & Update
 
@@ -88,6 +91,21 @@ golazo
 ```
 
 **Navigation:** `↑`/`↓` or `j`/`k` to move, `Enter` to select, `/` to filter, `Tab` to focus view, `Esc` to go back, `q` to quit.
+
+## CLI / Agent Mode
+
+For scripts and agentic tools (Claude Code, Codex, MCP servers), Golazo exposes JSON subcommands:
+
+```bash
+golazo capabilities | jq .                       # self-discover the contract
+golazo live                                       # live matches right now
+golazo finished --include-upcoming                # today's full slate
+golazo finished --days 3                          # last 3 days
+golazo match <id>                                 # full match details (chain from a list call)
+golazo leagues --all                              # every supported league
+```
+
+Full contract — JSON envelope, error codes, exit codes, retry policy, schema, jq recipes — in **[docs/CLI.md](docs/CLI.md)**.
 
 ## Docs
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ golazo
 
 - [Supported Leagues](docs/SUPPORTED_LEAGUES.md): Full list of available leagues and competitions, customize your preferences in the **Settings** menu.
 - [Notifications](docs/NOTIFICATIONS.md): Desktop notification setup and configuration
+- [CLI / Agent Mode](docs/CLI.md): JSON subcommands for agents and scripts (`golazo live`, `finished`, `match`, `leagues`)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ golazo capabilities | jq .                       # self-discover the contract
 golazo live                                       # live matches right now
 golazo finished --include-upcoming                # today's full slate
 golazo finished --days 3                          # last 3 days
-golazo match <id>                                 # full match details (chain from a list call)
+golazo match 2001 --mock                          # full match details (best-effort against real IDs; reliable with --mock)
 golazo leagues --all                              # every supported league
 ```
 

--- a/cmd/capabilities.go
+++ b/cmd/capabilities.go
@@ -1,0 +1,166 @@
+package cmd
+
+import (
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// CapabilitiesSchemaVersion identifies the contract version of the capabilities
+// payload. Bump when fields are added/changed so agents can pin against it.
+const CapabilitiesSchemaVersion = "1"
+
+// capabilityFlag describes a single flag in machine-readable form.
+type capabilityFlag struct {
+	Name        string `json:"name"`
+	Type        string `json:"type"`
+	Default     any    `json:"default,omitempty"`
+	Description string `json:"description"`
+}
+
+// capabilityCommand describes a single subcommand.
+type capabilityCommand struct {
+	Name        string           `json:"name"`
+	Description string           `json:"description"`
+	Args        string           `json:"args,omitempty"`
+	Flags       []capabilityFlag `json:"flags"`
+	Example     string           `json:"example"`
+	ExitCodes   []int            `json:"exit_codes"`
+}
+
+// capabilities is the machine-readable contract published by `golazo capabilities`.
+type capabilities struct {
+	SchemaVersion string              `json:"schema_version"`
+	Tool          string              `json:"tool"`
+	Description   string              `json:"description"`
+	Docs          string              `json:"docs"`
+	Commands      []capabilityCommand `json:"commands"`
+	ErrorCodes    map[string]int      `json:"error_codes"`
+	ExitCodes     map[string]string   `json:"exit_codes"`
+	EnvVars       map[string]string   `json:"env_vars"`
+	Envelope      map[string]any      `json:"envelope"`
+}
+
+// buildCapabilities returns the static capabilities payload. Kept in code (not
+// JSON file) so the contract stays in lockstep with the actual subcommands.
+func buildCapabilities() capabilities {
+	commonFlags := []capabilityFlag{
+		{Name: "mock", Type: "bool", Default: false, Description: "Use bundled mock data, no network"},
+		{Name: "debug", Type: "bool", Default: false, Description: "Emit debug logs to stderr"},
+		{Name: "timeout", Type: "duration", Default: "15s", Description: "Overall request timeout"},
+		{Name: "pretty", Type: "bool", Default: false, Description: "Indent JSON output"},
+	}
+	finishedFlagDefs := append([]capabilityFlag{}, commonFlags...)
+	finishedFlagDefs = append(finishedFlagDefs,
+		capabilityFlag{Name: "days", Type: "int", Default: 1, Description: "Number of days to look back (1..7)"},
+		capabilityFlag{Name: "include-upcoming", Type: "bool", Default: false, Description: "Also include today's not-yet-started matches"},
+	)
+	leaguesFlagDefs := append([]capabilityFlag{}, commonFlags...)
+	leaguesFlagDefs = append(leaguesFlagDefs,
+		capabilityFlag{Name: "all", Type: "bool", Default: false, Description: "List every supported league, not just the active selection"},
+	)
+
+	return capabilities{
+		SchemaVersion: CapabilitiesSchemaVersion,
+		Tool:          "golazo",
+		Description:   "JSON CLI for football match data (live, finished, details, leagues)",
+		Docs:          "https://github.com/0xjuanma/golazo/blob/main/docs/CLI.md",
+		Commands: []capabilityCommand{
+			{
+				Name:        "live",
+				Description: "List live matches across active leagues",
+				Flags:       commonFlags,
+				Example:     "golazo live",
+				ExitCodes:   []int{ExitOK, ExitUpstream, ExitTimeout, ExitOffline},
+			},
+			{
+				Name:        "finished",
+				Description: "List finished matches over a day window; optionally include today's upcoming matches",
+				Flags:       finishedFlagDefs,
+				Example:     "golazo finished --days 3 --include-upcoming",
+				ExitCodes:   []int{ExitOK, ExitUpstream, ExitInvalidArgs, ExitTimeout, ExitOffline},
+			},
+			{
+				Name:        "match",
+				Description: "Get full match details (events, lineups, stats) for an ID returned by `live` or `finished`",
+				Args:        "<id>",
+				Flags:       commonFlags,
+				Example:     "golazo finished | jq -r '.data[0].id' | xargs golazo match",
+				ExitCodes:   []int{ExitOK, ExitUpstream, ExitInvalidArgs, ExitNotFound, ExitTimeout, ExitOffline},
+			},
+			{
+				Name:        "leagues",
+				Description: "List active leagues (or all supported leagues with --all). No network calls.",
+				Flags:       leaguesFlagDefs,
+				Example:     "golazo leagues --all",
+				ExitCodes:   []int{ExitOK},
+			},
+			{
+				Name:        "capabilities",
+				Description: "Print this machine-readable contract describing every subcommand, flag, error and exit code",
+				Flags:       []capabilityFlag{{Name: "pretty", Type: "bool", Default: false, Description: "Indent JSON output"}},
+				Example:     "golazo capabilities | jq .commands",
+				ExitCodes:   []int{ExitOK},
+			},
+		},
+		ErrorCodes: map[string]int{
+			string(ErrCodeInvalidArgs):   ExitInvalidArgs,
+			string(ErrCodeNotFound):      ExitNotFound,
+			string(ErrCodeUpstreamError): ExitUpstream,
+			string(ErrCodeTimeout):       ExitTimeout,
+			string(ErrCodeOffline):       ExitOffline,
+		},
+		ExitCodes: map[string]string{
+			"0": "ok",
+			"1": "upstream_error",
+			"2": "invalid_args",
+			"3": "not_found",
+			"4": "timeout",
+			"5": "offline",
+		},
+		EnvVars: map[string]string{
+			EnvAgent:   "Forces compact JSON, enables stderr debug logging",
+			EnvOffline: "Refuses any network call; subcommands return offline unless --mock is set",
+		},
+		Envelope: map[string]any{
+			"success":  map[string]any{"status": "ok", "count": "int", "data": "[]object", "degraded": "bool (optional)", "failed_dates": "[]string (optional)"},
+			"error":    map[string]any{"status": "error", "code": "string", "message": "string"},
+			"notes": []string{
+				"Errors always go to stderr; stdout stays empty on error.",
+				"Single-item responses (match <id>) still use a data array with count: 1.",
+				"List output is sorted by match_time then id for deterministic ordering.",
+			},
+		},
+	}
+}
+
+var capabilitiesFlagSet cliFlags
+
+// runCapabilities is the testable core of the `capabilities` subcommand.
+func runCapabilities(stdout, stderr io.Writer, flags cliFlags) int {
+	applyPretty(flags)
+	if err := WriteJSON(stdout, []capabilities{buildCapabilities()}); err != nil {
+		return WriteError(stderr, ErrCodeUpstreamError, err)
+	}
+	return ExitOK
+}
+
+var capabilitiesCmd = &cobra.Command{
+	Use:           "capabilities",
+	Short:         "Print a machine-readable description of every subcommand",
+	Long:          "Emits a JSON envelope describing every subcommand, flag, error code, exit code and env var. Designed for agentic tools (Claude Code, Codex, MCP servers) to self-discover the CLI contract at session start.",
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	Run: func(cmd *cobra.Command, args []string) {
+		code := runCapabilities(os.Stdout, os.Stderr, capabilitiesFlagSet)
+		if code != ExitOK {
+			os.Exit(code)
+		}
+	},
+}
+
+func init() {
+	addCommonCLIFlags(capabilitiesCmd, &capabilitiesFlagSet)
+	rootCmd.AddCommand(capabilitiesCmd)
+}

--- a/cmd/capabilities.go
+++ b/cmd/capabilities.go
@@ -88,10 +88,10 @@ func buildCapabilities() capabilities {
 			},
 			{
 				Name:        "match",
-				Description: "Get full match details (events, lineups, stats) for an ID returned by `live` or `finished`",
+				Description: "Get full match details (events, lineups, stats). BEST-EFFORT ONLY — cold calls against arbitrary IDs typically fail with upstream_error due to a FotMob slug-cache constraint. Reliable only with --mock or from the TUI. Not recommended for production agent pipelines.",
 				Args:        "<id>",
 				Flags:       commonFlags,
-				Example:     "golazo finished | jq -r '.data[0].id' | xargs golazo match",
+				Example:     "golazo match 2001 --mock",
 				ExitCodes:   []int{ExitOK, ExitUpstream, ExitInvalidArgs, ExitNotFound, ExitTimeout, ExitOffline},
 			},
 			{

--- a/cmd/capabilities.go
+++ b/cmd/capabilities.go
@@ -51,12 +51,17 @@ func buildCapabilities() capabilities {
 		{Name: "timeout", Type: "duration", Default: "15s", Description: "Overall request timeout"},
 		{Name: "pretty", Type: "bool", Default: false, Description: "Indent JSON output"},
 	}
+	// Read-only subcommands (no network I/O) expose only --pretty so agents
+	// don't see inert flags in the contract.
+	prettyOnly := []capabilityFlag{
+		{Name: "pretty", Type: "bool", Default: false, Description: "Indent JSON output"},
+	}
 	finishedFlagDefs := append([]capabilityFlag{}, commonFlags...)
 	finishedFlagDefs = append(finishedFlagDefs,
 		capabilityFlag{Name: "days", Type: "int", Default: 1, Description: "Number of days to look back (1..7)"},
 		capabilityFlag{Name: "include-upcoming", Type: "bool", Default: false, Description: "Also include today's not-yet-started matches"},
 	)
-	leaguesFlagDefs := append([]capabilityFlag{}, commonFlags...)
+	leaguesFlagDefs := append([]capabilityFlag{}, prettyOnly...)
 	leaguesFlagDefs = append(leaguesFlagDefs,
 		capabilityFlag{Name: "all", Type: "bool", Default: false, Description: "List every supported league, not just the active selection"},
 	)
@@ -99,8 +104,8 @@ func buildCapabilities() capabilities {
 			{
 				Name:        "capabilities",
 				Description: "Print this machine-readable contract describing every subcommand, flag, error and exit code",
-				Flags:       []capabilityFlag{{Name: "pretty", Type: "bool", Default: false, Description: "Indent JSON output"}},
-				Example:     "golazo capabilities | jq .commands",
+				Flags:       prettyOnly,
+				Example:     "golazo capabilities | jq '.data[0].commands'",
 				ExitCodes:   []int{ExitOK},
 			},
 		},
@@ -161,6 +166,6 @@ var capabilitiesCmd = &cobra.Command{
 }
 
 func init() {
-	addCommonCLIFlags(capabilitiesCmd, &capabilitiesFlagSet)
+	addPrettyOnlyFlag(capabilitiesCmd, &capabilitiesFlagSet)
 	rootCmd.AddCommand(capabilitiesCmd)
 }

--- a/cmd/capabilities_test.go
+++ b/cmd/capabilities_test.go
@@ -1,0 +1,84 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func TestRunCapabilities_EmitsContract(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := runCapabilities(&stdout, &stderr, cliFlags{})
+	if code != ExitOK {
+		t.Fatalf("exit = %d, stderr=%s", code, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("stderr should be empty, got: %s", stderr.String())
+	}
+
+	var env struct {
+		Status string         `json:"status"`
+		Count  int            `json:"count"`
+		Data   []capabilities `json:"data"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal: %v\nraw: %s", err, stdout.String())
+	}
+	if env.Status != "ok" {
+		t.Errorf("status = %q", env.Status)
+	}
+	if len(env.Data) != 1 {
+		t.Fatalf("expected 1 capabilities entry, got %d", len(env.Data))
+	}
+	caps := env.Data[0]
+	if caps.SchemaVersion != CapabilitiesSchemaVersion {
+		t.Errorf("schema_version = %q, want %q", caps.SchemaVersion, CapabilitiesSchemaVersion)
+	}
+	if caps.Tool != "golazo" {
+		t.Errorf("tool = %q, want golazo", caps.Tool)
+	}
+}
+
+func TestCapabilities_EnumeratesAllSubcommands(t *testing.T) {
+	caps := buildCapabilities()
+	want := map[string]bool{
+		"live":         false,
+		"finished":     false,
+		"match":        false,
+		"leagues":      false,
+		"capabilities": false,
+	}
+	for _, cmd := range caps.Commands {
+		if _, ok := want[cmd.Name]; ok {
+			want[cmd.Name] = true
+		}
+	}
+	for name, found := range want {
+		if !found {
+			t.Errorf("subcommand %q missing from capabilities payload", name)
+		}
+	}
+}
+
+func TestCapabilities_ErrorCodesMatchExitCodes(t *testing.T) {
+	caps := buildCapabilities()
+	// The error_codes map must be consistent with cli_output.go's ExitCodeFor.
+	for code, exit := range caps.ErrorCodes {
+		got := ExitCodeFor(ErrorCode(code))
+		if got != exit {
+			t.Errorf("error_codes[%q] = %d, but ExitCodeFor returns %d", code, exit, got)
+		}
+	}
+}
+
+func TestCapabilities_EveryCommandHasExample(t *testing.T) {
+	caps := buildCapabilities()
+	for _, cmd := range caps.Commands {
+		if cmd.Example == "" {
+			t.Errorf("command %q has empty example — agents rely on this", cmd.Name)
+		}
+		if cmd.Description == "" {
+			t.Errorf("command %q has empty description", cmd.Name)
+		}
+	}
+}

--- a/cmd/capabilities_test.go
+++ b/cmd/capabilities_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"testing"
+
+	"github.com/spf13/pflag"
 )
 
 func TestRunCapabilities_EmitsContract(t *testing.T) {
@@ -79,6 +81,47 @@ func TestCapabilities_EveryCommandHasExample(t *testing.T) {
 		}
 		if cmd.Description == "" {
 			t.Errorf("command %q has empty description", cmd.Name)
+		}
+	}
+}
+
+// TestCapabilities_FlagsMatchCobra protects the contract from drifting away
+// from the actual cobra flag set. If you add or remove a flag on a subcommand,
+// you must also update buildCapabilities() to match.
+func TestCapabilities_FlagsMatchCobra(t *testing.T) {
+	caps := buildCapabilities()
+	capsByName := map[string]capabilityCommand{}
+	for _, c := range caps.Commands {
+		capsByName[c.Name] = c
+	}
+
+	for _, cobraCmd := range rootCmd.Commands() {
+		entry, ok := capsByName[cobraCmd.Name()]
+		if !ok {
+			continue // cobra builtins (help, completion) aren't in the contract
+		}
+
+		cobraFlagNames := map[string]bool{}
+		cobraCmd.Flags().VisitAll(func(f *pflag.Flag) {
+			cobraFlagNames[f.Name] = true
+		})
+		// Strip the inherited `help` flag — cobra adds it automatically.
+		delete(cobraFlagNames, "help")
+
+		capsFlagNames := map[string]bool{}
+		for _, f := range entry.Flags {
+			capsFlagNames[f.Name] = true
+		}
+
+		for name := range cobraFlagNames {
+			if !capsFlagNames[name] {
+				t.Errorf("subcommand %q exposes --%s but capabilities contract omits it", cobraCmd.Name(), name)
+			}
+		}
+		for name := range capsFlagNames {
+			if !cobraFlagNames[name] {
+				t.Errorf("capabilities contract claims subcommand %q has --%s but cobra doesn't expose it", cobraCmd.Name(), name)
+			}
 		}
 	}
 }

--- a/cmd/cli_output.go
+++ b/cmd/cli_output.go
@@ -168,6 +168,8 @@ func sliceLen(v any) int {
 		return len(s)
 	}
 	// Single-object fallback. Callers are expected to wrap singles in []T.
+	// Slices of an unrecognized type fall through here too and report 1; if
+	// you add a new agent-facing list type, register it above.
 	return 1
 }
 

--- a/cmd/cli_output.go
+++ b/cmd/cli_output.go
@@ -1,0 +1,209 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+
+	"github.com/0xjuanma/golazo/internal/api"
+)
+
+// ErrorCode is a typed, machine-readable error category for CLI consumers.
+type ErrorCode string
+
+const (
+	ErrCodeInvalidArgs   ErrorCode = "invalid_args"
+	ErrCodeNotFound      ErrorCode = "not_found"
+	ErrCodeUpstreamError ErrorCode = "upstream_error"
+	ErrCodeTimeout       ErrorCode = "timeout"
+	ErrCodeOffline       ErrorCode = "offline"
+)
+
+// Exit codes mapped from ErrorCode. Documented in docs/cli.md.
+const (
+	ExitOK           = 0
+	ExitUpstream     = 1
+	ExitInvalidArgs  = 2
+	ExitNotFound     = 3
+	ExitTimeout      = 4
+	ExitOffline      = 5
+)
+
+// ExitCodeFor returns the documented exit code for a given ErrorCode.
+func ExitCodeFor(code ErrorCode) int {
+	switch code {
+	case ErrCodeInvalidArgs:
+		return ExitInvalidArgs
+	case ErrCodeNotFound:
+		return ExitNotFound
+	case ErrCodeTimeout:
+		return ExitTimeout
+	case ErrCodeOffline:
+		return ExitOffline
+	case ErrCodeUpstreamError:
+		return ExitUpstream
+	default:
+		return ExitUpstream
+	}
+}
+
+// okEnvelope is the shape returned on success.
+type okEnvelope struct {
+	Status        string `json:"status"`
+	Degraded      bool   `json:"degraded,omitempty"`
+	FailedDates   []string `json:"failed_dates,omitempty"`
+	Count         int    `json:"count"`
+	Data          any    `json:"data"`
+}
+
+// errEnvelope is the shape returned on failure.
+type errEnvelope struct {
+	Status  string    `json:"status"`
+	Code    ErrorCode `json:"code"`
+	Message string    `json:"message"`
+}
+
+// Pretty controls whether JSON is indented. Default is compact (agent-friendly).
+var Pretty bool
+
+// WriteJSON writes a successful envelope to w. count is set from data length
+// when data is a slice; for single-object responses callers should wrap in
+// a one-element slice so count stays consistent.
+func WriteJSON(w io.Writer, data any) error {
+	env := okEnvelope{
+		Status: "ok",
+		Count:  sliceLen(data),
+		Data:   nonNilSlice(data),
+	}
+	return encode(w, env)
+}
+
+// WriteDegraded writes a successful envelope flagged as degraded. failedDates
+// is the list of date strings (YYYY-MM-DD) whose upstream fetch failed but
+// other days succeeded.
+func WriteDegraded(w io.Writer, data any, failedDates []string) error {
+	env := okEnvelope{
+		Status:      "ok",
+		Degraded:    true,
+		FailedDates: failedDates,
+		Count:       sliceLen(data),
+		Data:        nonNilSlice(data),
+	}
+	return encode(w, env)
+}
+
+// WriteError writes the error envelope to w (typically stderr) and returns
+// the documented exit code for the given ErrorCode.
+func WriteError(w io.Writer, code ErrorCode, err error) int {
+	msg := ""
+	if err != nil {
+		msg = err.Error()
+	}
+	env := errEnvelope{
+		Status:  "error",
+		Code:    code,
+		Message: msg,
+	}
+	_ = encode(w, env)
+	return ExitCodeFor(code)
+}
+
+// ClassifyClientError maps a transport/client error to an ErrorCode.
+// Callers pass an error from a fotmob.Client call and a flag indicating
+// whether the context deadline was exceeded.
+func ClassifyClientError(err error, timedOut bool) ErrorCode {
+	if err == nil {
+		return ErrCodeUpstreamError
+	}
+	if timedOut {
+		return ErrCodeTimeout
+	}
+	return ErrCodeUpstreamError
+}
+
+// SortMatches sorts matches deterministically by MatchTime (nils last) then ID.
+// In-place sort.
+func SortMatches(matches []api.Match) {
+	sort.SliceStable(matches, func(i, j int) bool {
+		a, b := matches[i], matches[j]
+		switch {
+		case a.MatchTime != nil && b.MatchTime != nil:
+			if !a.MatchTime.Equal(*b.MatchTime) {
+				return a.MatchTime.Before(*b.MatchTime)
+			}
+		case a.MatchTime != nil && b.MatchTime == nil:
+			return true
+		case a.MatchTime == nil && b.MatchTime != nil:
+			return false
+		}
+		return a.ID < b.ID
+	})
+}
+
+func encode(w io.Writer, v any) error {
+	enc := json.NewEncoder(w)
+	if Pretty {
+		enc.SetIndent("", "  ")
+	}
+	enc.SetEscapeHTML(false)
+	return enc.Encode(v)
+}
+
+// sliceLen returns the length when v is a slice; otherwise 0 if nil, else 1.
+func sliceLen(v any) int {
+	switch s := v.(type) {
+	case nil:
+		return 0
+	case []api.Match:
+		return len(s)
+	case []api.MatchDetails:
+		return len(s)
+	case []api.League:
+		return len(s)
+	case []api.LeagueTableEntry:
+		return len(s)
+	case []any:
+		return len(s)
+	}
+	// Single-object fallback. Callers are expected to wrap singles in []T.
+	return 1
+}
+
+// nonNilSlice returns v unless v is a nil slice; in that case it returns an
+// empty slice of the same element type so JSON encodes `[]` instead of `null`.
+func nonNilSlice(v any) any {
+	switch s := v.(type) {
+	case []api.Match:
+		if s == nil {
+			return []api.Match{}
+		}
+	case []api.MatchDetails:
+		if s == nil {
+			return []api.MatchDetails{}
+		}
+	case []api.League:
+		if s == nil {
+			return []api.League{}
+		}
+	case []api.LeagueTableEntry:
+		if s == nil {
+			return []api.LeagueTableEntry{}
+		}
+	case []any:
+		if s == nil {
+			return []any{}
+		}
+	}
+	return v
+}
+
+// errInvalidArg is a sentinel for invalid argument errors so callers can build
+// a precise message without re-classifying.
+var errInvalidArg = errors.New("invalid argument")
+
+// NewInvalidArg returns an error wrapping errInvalidArg with a formatted msg.
+func NewInvalidArg(format string, args ...any) error {
+	return fmt.Errorf("%w: "+format, append([]any{errInvalidArg}, args...)...)
+}

--- a/cmd/cli_output_test.go
+++ b/cmd/cli_output_test.go
@@ -1,0 +1,189 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/0xjuanma/golazo/internal/api"
+)
+
+func TestWriteJSON_EmptySlice(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteJSON(&buf, []api.Match(nil)); err != nil {
+		t.Fatalf("WriteJSON returned error: %v", err)
+	}
+
+	var env struct {
+		Status string       `json:"status"`
+		Count  int          `json:"count"`
+		Data   []api.Match  `json:"data"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal: %v\nraw: %s", err, buf.String())
+	}
+	if env.Status != "ok" {
+		t.Errorf("status = %q, want ok", env.Status)
+	}
+	if env.Count != 0 {
+		t.Errorf("count = %d, want 0", env.Count)
+	}
+	if env.Data == nil {
+		t.Errorf("data is null; want empty array")
+	}
+	if len(env.Data) != 0 {
+		t.Errorf("data length = %d, want 0", len(env.Data))
+	}
+	// Verify raw output does not contain "null"
+	if bytes.Contains(buf.Bytes(), []byte("null")) {
+		t.Errorf("output contains null token: %s", buf.String())
+	}
+}
+
+func TestWriteJSON_SliceWithItems(t *testing.T) {
+	matches := []api.Match{
+		{ID: 1, HomeTeam: api.Team{Name: "A"}, AwayTeam: api.Team{Name: "B"}},
+		{ID: 2, HomeTeam: api.Team{Name: "C"}, AwayTeam: api.Team{Name: "D"}},
+	}
+	var buf bytes.Buffer
+	if err := WriteJSON(&buf, matches); err != nil {
+		t.Fatalf("WriteJSON: %v", err)
+	}
+	var env okEnvelope
+	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if env.Count != 2 {
+		t.Errorf("count = %d, want 2", env.Count)
+	}
+	if env.Status != "ok" {
+		t.Errorf("status = %q", env.Status)
+	}
+	if env.Degraded {
+		t.Errorf("degraded should be false")
+	}
+}
+
+func TestWriteDegraded(t *testing.T) {
+	matches := []api.Match{{ID: 1}}
+	var buf bytes.Buffer
+	if err := WriteDegraded(&buf, matches, []string{"2026-06-10", "2026-06-11"}); err != nil {
+		t.Fatalf("WriteDegraded: %v", err)
+	}
+	var env struct {
+		Status      string   `json:"status"`
+		Degraded    bool     `json:"degraded"`
+		FailedDates []string `json:"failed_dates"`
+		Count       int      `json:"count"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !env.Degraded {
+		t.Errorf("degraded should be true")
+	}
+	if len(env.FailedDates) != 2 {
+		t.Errorf("failed_dates length = %d, want 2", len(env.FailedDates))
+	}
+	if env.Count != 1 {
+		t.Errorf("count = %d, want 1", env.Count)
+	}
+}
+
+func TestWriteError_WritesAndReturnsExitCode(t *testing.T) {
+	cases := []struct {
+		code     ErrorCode
+		exitCode int
+	}{
+		{ErrCodeInvalidArgs, ExitInvalidArgs},
+		{ErrCodeNotFound, ExitNotFound},
+		{ErrCodeTimeout, ExitTimeout},
+		{ErrCodeOffline, ExitOffline},
+		{ErrCodeUpstreamError, ExitUpstream},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.code), func(t *testing.T) {
+			var buf bytes.Buffer
+			got := WriteError(&buf, tc.code, errors.New("boom"))
+			if got != tc.exitCode {
+				t.Errorf("exit code = %d, want %d", got, tc.exitCode)
+			}
+			var env errEnvelope
+			if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if env.Status != "error" {
+				t.Errorf("status = %q", env.Status)
+			}
+			if env.Code != tc.code {
+				t.Errorf("code = %q, want %q", env.Code, tc.code)
+			}
+			if env.Message != "boom" {
+				t.Errorf("message = %q", env.Message)
+			}
+		})
+	}
+}
+
+func TestExitCodeFor_UnknownDefaults(t *testing.T) {
+	if got := ExitCodeFor(ErrorCode("nope")); got != ExitUpstream {
+		t.Errorf("unknown code exit = %d, want %d", got, ExitUpstream)
+	}
+}
+
+func TestSortMatches_TimeThenID(t *testing.T) {
+	t1 := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 6, 10, 18, 0, 0, 0, time.UTC)
+	matches := []api.Match{
+		{ID: 9, MatchTime: &t2},
+		{ID: 5, MatchTime: nil},
+		{ID: 3, MatchTime: &t1},
+		{ID: 7, MatchTime: &t1},
+	}
+	SortMatches(matches)
+	wantIDs := []int{3, 7, 9, 5}
+	for i, want := range wantIDs {
+		if matches[i].ID != want {
+			t.Errorf("position %d: got id=%d, want %d (full=%v)", i, matches[i].ID, want, idsOf(matches))
+		}
+	}
+}
+
+func TestClassifyClientError(t *testing.T) {
+	if got := ClassifyClientError(errors.New("x"), true); got != ErrCodeTimeout {
+		t.Errorf("timedOut=true → %q, want %q", got, ErrCodeTimeout)
+	}
+	if got := ClassifyClientError(errors.New("x"), false); got != ErrCodeUpstreamError {
+		t.Errorf("timedOut=false → %q, want %q", got, ErrCodeUpstreamError)
+	}
+}
+
+func TestPrettyToggle(t *testing.T) {
+	prev := Pretty
+	defer func() { Pretty = prev }()
+
+	Pretty = false
+	var compact bytes.Buffer
+	_ = WriteJSON(&compact, []api.Match{{ID: 1}})
+
+	Pretty = true
+	var pretty bytes.Buffer
+	_ = WriteJSON(&pretty, []api.Match{{ID: 1}})
+
+	if !bytes.Contains(pretty.Bytes(), []byte("\n  ")) {
+		t.Errorf("pretty output not indented: %s", pretty.String())
+	}
+	if bytes.Contains(compact.Bytes(), []byte("\n  ")) {
+		t.Errorf("compact output was indented: %s", compact.String())
+	}
+}
+
+func idsOf(matches []api.Match) []int {
+	out := make([]int, len(matches))
+	for i, m := range matches {
+		out[i] = m.ID
+	}
+	return out
+}

--- a/cmd/cli_runtime.go
+++ b/cmd/cli_runtime.go
@@ -1,0 +1,84 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/0xjuanma/golazo/internal/fotmob"
+)
+
+// Env vars recognized by the CLI subcommands.
+const (
+	EnvAgent   = "GOLAZO_AGENT"   // "1" forces compact JSON, stderr debug logging
+	EnvOffline = "GOLAZO_OFFLINE" // "1" refuses any network call
+)
+
+// runtimeOpts captures the per-invocation runtime configuration.
+type runtimeOpts struct {
+	mock    bool
+	debug   bool
+	timeout time.Duration
+}
+
+// ErrOffline is returned when GOLAZO_OFFLINE is set and the subcommand needs
+// network access (mock-mode callers may ignore this).
+var ErrOffline = errors.New("network access disabled via GOLAZO_OFFLINE")
+
+// agentMode returns true when GOLAZO_AGENT=1.
+func agentMode() bool {
+	return os.Getenv(EnvAgent) == "1"
+}
+
+// offlineMode returns true when GOLAZO_OFFLINE=1.
+func offlineMode() bool {
+	return os.Getenv(EnvOffline) == "1"
+}
+
+// newStderrLogger returns a slog.Logger writing to stderr at Debug level when
+// debug or agent mode is on. Otherwise a no-op logger.
+//
+// Stdout is reserved for the JSON envelope; logs MUST go to stderr.
+func newStderrLogger(debug bool) *slog.Logger {
+	if !debug && !agentMode() {
+		return slog.New(slog.NewTextHandler(io.Discard, nil))
+	}
+	handler := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})
+	return slog.New(handler).With("source", "golazo")
+}
+
+// newHeadlessClient builds a fotmob.Client without the TUI's background
+// version-check goroutine. Honors GOLAZO_OFFLINE by returning ErrOffline
+// when the caller is not in mock mode.
+//
+// Returns the client, a context bounded by opts.timeout (default 15s), and
+// the cancel function the caller MUST invoke.
+func newHeadlessClient(opts runtimeOpts) (*fotmob.Client, context.Context, context.CancelFunc, error) {
+	if offlineMode() && !opts.mock {
+		// Provide a no-op cancel so callers can defer unconditionally.
+		return nil, nil, func() {}, ErrOffline
+	}
+
+	timeout := opts.timeout
+	if timeout <= 0 {
+		timeout = 15 * time.Second
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+
+	// In mock mode we still return a client (callers branch on opts.mock and
+	// use data.Mock* sources), but we skip wiring an HTTP-bound logger when
+	// not needed.
+	client := fotmob.NewClient()
+	client.SetLogger(newStderrLogger(opts.debug))
+
+	return client, ctx, cancel, nil
+}
+
+// isTimeout reports whether ctx's deadline was exceeded.
+func isTimeout(ctx context.Context) bool {
+	return ctx != nil && errors.Is(ctx.Err(), context.DeadlineExceeded)
+}

--- a/cmd/cli_runtime_test.go
+++ b/cmd/cli_runtime_test.go
@@ -1,0 +1,94 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestNewHeadlessClient_OfflineReturnsError(t *testing.T) {
+	t.Setenv(EnvOffline, "1")
+	_, _, cancel, err := newHeadlessClient(runtimeOpts{mock: false, timeout: time.Second})
+	defer cancel()
+	if !errors.Is(err, ErrOffline) {
+		t.Errorf("err = %v, want ErrOffline", err)
+	}
+}
+
+func TestNewHeadlessClient_OfflineButMockSucceeds(t *testing.T) {
+	t.Setenv(EnvOffline, "1")
+	client, ctx, cancel, err := newHeadlessClient(runtimeOpts{mock: true, timeout: time.Second})
+	defer cancel()
+	if err != nil {
+		t.Fatalf("mock under offline should succeed, got err=%v", err)
+	}
+	if client == nil {
+		t.Errorf("client is nil")
+	}
+	if ctx == nil {
+		t.Errorf("ctx is nil")
+	}
+}
+
+func TestNewHeadlessClient_DefaultsToTimeout(t *testing.T) {
+	t.Setenv(EnvOffline, "")
+	_, ctx, cancel, err := newHeadlessClient(runtimeOpts{timeout: 0})
+	defer cancel()
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatalf("ctx has no deadline")
+	}
+	// Default is 15s; allow slack.
+	if d := time.Until(deadline); d < 10*time.Second || d > 20*time.Second {
+		t.Errorf("default timeout deadline = %v from now, want ~15s", d)
+	}
+}
+
+func TestNewHeadlessClient_RespectsCustomTimeout(t *testing.T) {
+	t.Setenv(EnvOffline, "")
+	_, ctx, cancel, err := newHeadlessClient(runtimeOpts{timeout: 5 * time.Millisecond})
+	defer cancel()
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	// Wait for the context to expire and verify isTimeout reports it.
+	<-ctx.Done()
+	if !isTimeout(ctx) {
+		t.Errorf("isTimeout returned false on deadline-exceeded ctx (err=%v)", ctx.Err())
+	}
+}
+
+func TestIsTimeout_CancelledIsNotTimeout(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if isTimeout(ctx) {
+		t.Errorf("cancelled ctx classified as timeout")
+	}
+}
+
+func TestAgentMode(t *testing.T) {
+	t.Setenv(EnvAgent, "1")
+	if !agentMode() {
+		t.Errorf("agentMode = false with GOLAZO_AGENT=1")
+	}
+	t.Setenv(EnvAgent, "")
+	if agentMode() {
+		t.Errorf("agentMode = true with empty env")
+	}
+}
+
+func TestNewStderrLogger_NoopWhenDisabled(t *testing.T) {
+	t.Setenv(EnvAgent, "")
+	logger := newStderrLogger(false)
+	if logger == nil {
+		t.Fatalf("logger nil")
+	}
+	// We can't easily intercept stderr; assert that the handler is non-nil
+	// and that the logger does not panic. The hard contract (stderr only)
+	// is enforced by code review of the constructor.
+	logger.Debug("noop")
+}

--- a/cmd/finished.go
+++ b/cmd/finished.go
@@ -151,7 +151,13 @@ func runFinished(stdout, stderr io.Writer, flags finishedFlags) int {
 var finishedCmd = &cobra.Command{
 	Use:           "finished",
 	Short:         "List finished matches over a day window as JSON",
-	Long:          "Fetches finished matches for the last --days days (default 1 = today) across active leagues. Use --include-upcoming to also include today's not-yet-started matches. Partial failures surface as degraded:true with failed_dates listed.",
+	Long: `Fetches finished matches for the last --days days (default 1 = today) across active leagues. Use --include-upcoming to also include today's not-yet-started matches. Partial failures surface as degraded:true with failed_dates listed.
+
+Example output:
+  {"status":"ok","count":2,"data":[{"id":4506420,"league":{"id":47,"name":"Premier League","country":"England"},"home_team":{"name":"Liverpool","short_name":"Liverpool"},"away_team":{"name":"Arsenal","short_name":"Arsenal"},"status":"finished","home_score":3,"away_score":1,"match_time":"2026-06-12T15:00:00Z"}]}
+
+Degraded example (one date failed but others succeeded):
+  {"status":"ok","degraded":true,"failed_dates":["2026-06-10"],"count":12,"data":[...]}`,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/finished.go
+++ b/cmd/finished.go
@@ -1,0 +1,151 @@
+package cmd
+
+import (
+	"context"
+	"io"
+	"os"
+	"time"
+
+	"github.com/0xjuanma/golazo/internal/api"
+	"github.com/0xjuanma/golazo/internal/data"
+	"github.com/0xjuanma/golazo/internal/fotmob"
+	"github.com/spf13/cobra"
+)
+
+// MaxFinishedDays is the maximum supported lookback window for `golazo finished`.
+const MaxFinishedDays = 7
+
+// finishedDayFetcher abstracts MatchesByDateWithTabs for testing.
+type finishedDayFetcher func(ctx context.Context, date time.Time, tabs []string) ([]api.Match, error)
+
+// collectFinished iterates `days` calendar days ending today, calling the
+// per-day fetcher for each. It deduplicates by Match.ID and returns:
+//   - the union of finished matches
+//   - the list of date strings (YYYY-MM-DD) whose fetch failed
+//   - an error iff ALL days failed (callers may then return upstream_error)
+//
+// This is the layer where the multi-day, dedup, and degraded-surface behavior
+// lives, so tests target it directly.
+func collectFinished(ctx context.Context, fetch finishedDayFetcher, now time.Time, days int) ([]api.Match, []string, error) {
+	dedup := make(map[int]api.Match, days*10)
+	var failedDates []string
+	successCount := 0
+	var lastErr error
+
+	for i := 0; i < days; i++ {
+		date := now.AddDate(0, 0, -i).UTC()
+		dateStr := date.Format("2006-01-02")
+
+		// Today needs fixtures+results (TUI behavior); past days only need results.
+		tabs := []string{"results"}
+		if i == 0 {
+			tabs = []string{"fixtures", "results"}
+		}
+
+		matches, err := fetch(ctx, date, tabs)
+		if err != nil {
+			failedDates = append(failedDates, dateStr)
+			lastErr = err
+			continue
+		}
+		successCount++
+		for _, m := range matches {
+			if m.Status == api.MatchStatusFinished {
+				dedup[m.ID] = m
+			}
+		}
+	}
+
+	if successCount == 0 {
+		return nil, failedDates, lastErr
+	}
+
+	out := make([]api.Match, 0, len(dedup))
+	for _, m := range dedup {
+		out = append(out, m)
+	}
+	return out, failedDates, nil
+}
+
+func defaultFinishedFetcher(c *fotmob.Client) finishedDayFetcher {
+	return c.MatchesByDateWithTabs
+}
+
+// finishedFlags extends the common flag set with --days.
+type finishedFlags struct {
+	cliFlags
+	days int
+}
+
+var finishedFlagSet finishedFlags
+
+// runFinished is the testable core of the `finished` subcommand.
+func runFinished(stdout, stderr io.Writer, flags finishedFlags) int {
+	applyPretty(flags.cliFlags)
+
+	if flags.days < 1 || flags.days > MaxFinishedDays {
+		return WriteError(stderr, ErrCodeInvalidArgs,
+			NewInvalidArg("--days must be between 1 and %d, got %d", MaxFinishedDays, flags.days))
+	}
+
+	client, ctx, cancel, err := newHeadlessClient(runtimeOpts{
+		mock:    flags.mock,
+		debug:   flags.debug,
+		timeout: flags.timeout,
+	})
+	defer cancel()
+	if err == ErrOffline {
+		return WriteError(stderr, ErrCodeOffline, err)
+	}
+	if err != nil {
+		return WriteError(stderr, ErrCodeUpstreamError, err)
+	}
+
+	var (
+		matches     []api.Match
+		failedDates []string
+	)
+
+	if flags.mock {
+		// Mock data is single-day; serve it regardless of --days.
+		matches = data.MockFinishedMatches()
+	} else {
+		matches, failedDates, err = collectFinished(ctx, defaultFinishedFetcher(client), time.Now(), flags.days)
+		if err != nil {
+			return WriteError(stderr, ClassifyClientError(err, isTimeout(ctx)), err)
+		}
+	}
+
+	SortMatches(matches)
+
+	var writeErr error
+	if len(failedDates) > 0 {
+		writeErr = WriteDegraded(stdout, matches, failedDates)
+	} else {
+		writeErr = WriteJSON(stdout, matches)
+	}
+	if writeErr != nil {
+		return WriteError(stderr, ErrCodeUpstreamError, writeErr)
+	}
+	return ExitOK
+}
+
+var finishedCmd = &cobra.Command{
+	Use:           "finished",
+	Short:         "List finished matches over a day window as JSON",
+	Long:          "Fetches finished matches for the last --days days (default 1 = today) across active leagues. Partial failures surface as degraded:true with failed_dates listed.",
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	Run: func(cmd *cobra.Command, args []string) {
+		code := runFinished(os.Stdout, os.Stderr, finishedFlagSet)
+		if code != ExitOK {
+			os.Exit(code)
+		}
+	},
+}
+
+func init() {
+	addCommonCLIFlags(finishedCmd, &finishedFlagSet.cliFlags)
+	finishedCmd.Flags().IntVar(&finishedFlagSet.days, "days", 1, "Number of days to look back (1..7)")
+	rootCmd.AddCommand(finishedCmd)
+}

--- a/cmd/finished.go
+++ b/cmd/finished.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"time"
@@ -113,6 +114,13 @@ func runFinished(stdout, stderr io.Writer, flags finishedFlags) int {
 		matches, failedDates, err = collectFinished(ctx, defaultFinishedFetcher(client), time.Now(), flags.days)
 		if err != nil {
 			return WriteError(stderr, ClassifyClientError(err, isTimeout(ctx)), err)
+		}
+		// Guard against silent timeouts: per-day fetches may all swallow the
+		// cancellation and return empty without an error. Surface as timeout
+		// so agents can distinguish "no finished matches" from "timed out".
+		if isTimeout(ctx) {
+			return WriteError(stderr, ErrCodeTimeout,
+				fmt.Errorf("finished matches fetch timed out after %s", flags.timeout))
 		}
 	}
 

--- a/cmd/finished.go
+++ b/cmd/finished.go
@@ -27,7 +27,10 @@ type finishedDayFetcher func(ctx context.Context, date time.Time, tabs []string)
 //
 // This is the layer where the multi-day, dedup, and degraded-surface behavior
 // lives, so tests target it directly.
-func collectFinished(ctx context.Context, fetch finishedDayFetcher, now time.Time, days int) ([]api.Match, []string, error) {
+//
+// When includeUpcoming is true, today's not-yet-started matches are also
+// included in the result. Past days never contain not_started matches.
+func collectFinished(ctx context.Context, fetch finishedDayFetcher, now time.Time, days int, includeUpcoming bool) ([]api.Match, []string, error) {
 	dedup := make(map[int]api.Match, days*10)
 	var failedDates []string
 	successCount := 0
@@ -36,10 +39,11 @@ func collectFinished(ctx context.Context, fetch finishedDayFetcher, now time.Tim
 	for i := 0; i < days; i++ {
 		date := now.AddDate(0, 0, -i).UTC()
 		dateStr := date.Format("2006-01-02")
+		isToday := i == 0
 
 		// Today needs fixtures+results (TUI behavior); past days only need results.
 		tabs := []string{"results"}
-		if i == 0 {
+		if isToday {
 			tabs = []string{"fixtures", "results"}
 		}
 
@@ -51,8 +55,13 @@ func collectFinished(ctx context.Context, fetch finishedDayFetcher, now time.Tim
 		}
 		successCount++
 		for _, m := range matches {
-			if m.Status == api.MatchStatusFinished {
+			switch m.Status {
+			case api.MatchStatusFinished:
 				dedup[m.ID] = m
+			case api.MatchStatusNotStarted:
+				if includeUpcoming && isToday {
+					dedup[m.ID] = m
+				}
 			}
 		}
 	}
@@ -72,10 +81,11 @@ func defaultFinishedFetcher(c *fotmob.Client) finishedDayFetcher {
 	return c.MatchesByDateWithTabs
 }
 
-// finishedFlags extends the common flag set with --days.
+// finishedFlags extends the common flag set with --days and --include-upcoming.
 type finishedFlags struct {
 	cliFlags
-	days int
+	days            int
+	includeUpcoming bool
 }
 
 var finishedFlagSet finishedFlags
@@ -111,7 +121,7 @@ func runFinished(stdout, stderr io.Writer, flags finishedFlags) int {
 		// Mock data is single-day; serve it regardless of --days.
 		matches = data.MockFinishedMatches()
 	} else {
-		matches, failedDates, err = collectFinished(ctx, defaultFinishedFetcher(client), time.Now(), flags.days)
+		matches, failedDates, err = collectFinished(ctx, defaultFinishedFetcher(client), time.Now(), flags.days, flags.includeUpcoming)
 		if err != nil {
 			return WriteError(stderr, ClassifyClientError(err, isTimeout(ctx)), err)
 		}
@@ -141,7 +151,7 @@ func runFinished(stdout, stderr io.Writer, flags finishedFlags) int {
 var finishedCmd = &cobra.Command{
 	Use:           "finished",
 	Short:         "List finished matches over a day window as JSON",
-	Long:          "Fetches finished matches for the last --days days (default 1 = today) across active leagues. Partial failures surface as degraded:true with failed_dates listed.",
+	Long:          "Fetches finished matches for the last --days days (default 1 = today) across active leagues. Use --include-upcoming to also include today's not-yet-started matches. Partial failures surface as degraded:true with failed_dates listed.",
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -155,5 +165,6 @@ var finishedCmd = &cobra.Command{
 func init() {
 	addCommonCLIFlags(finishedCmd, &finishedFlagSet.cliFlags)
 	finishedCmd.Flags().IntVar(&finishedFlagSet.days, "days", 1, "Number of days to look back (1..7)")
+	finishedCmd.Flags().BoolVar(&finishedFlagSet.includeUpcoming, "include-upcoming", false, "Also include today's not-yet-started matches in the result")
 	rootCmd.AddCommand(finishedCmd)
 }

--- a/cmd/finished_test.go
+++ b/cmd/finished_test.go
@@ -1,0 +1,157 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/0xjuanma/golazo/internal/api"
+	"github.com/0xjuanma/golazo/internal/data"
+)
+
+func TestRunFinished_MockReturnsExpectedCount(t *testing.T) {
+	t.Setenv(EnvOffline, "")
+	t.Setenv(EnvAgent, "")
+
+	var stdout, stderr bytes.Buffer
+	code := runFinished(&stdout, &stderr, finishedFlags{cliFlags: cliFlags{mock: true, timeout: time.Second}, days: 1})
+
+	if code != ExitOK {
+		t.Fatalf("exit code = %d, want %d. stderr=%s", code, ExitOK, stderr.String())
+	}
+	var env struct {
+		Status string      `json:"status"`
+		Count  int         `json:"count"`
+		Data   []api.Match `json:"data"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal: %v\nraw: %s", err, stdout.String())
+	}
+	if env.Count != len(data.MockFinishedMatches()) {
+		t.Errorf("count = %d, want %d", env.Count, len(data.MockFinishedMatches()))
+	}
+}
+
+func TestRunFinished_InvalidDays(t *testing.T) {
+	cases := []int{0, -1, 8, 100}
+	for _, days := range cases {
+		t.Run("", func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code := runFinished(&stdout, &stderr, finishedFlags{cliFlags: cliFlags{mock: true, timeout: time.Second}, days: days})
+			if code != ExitInvalidArgs {
+				t.Errorf("days=%d: exit = %d, want %d", days, code, ExitInvalidArgs)
+			}
+			if stdout.Len() != 0 {
+				t.Errorf("stdout should be empty on invalid args, got: %s", stdout.String())
+			}
+			var env errEnvelope
+			if err := json.Unmarshal(stderr.Bytes(), &env); err != nil {
+				t.Fatalf("unmarshal stderr: %v", err)
+			}
+			if env.Code != ErrCodeInvalidArgs {
+				t.Errorf("code = %q, want %q", env.Code, ErrCodeInvalidArgs)
+			}
+		})
+	}
+}
+
+func TestCollectFinished_DedupsByID(t *testing.T) {
+	now := time.Date(2026, 6, 12, 12, 0, 0, 0, time.UTC)
+	calls := 0
+	fetch := func(ctx context.Context, date time.Time, tabs []string) ([]api.Match, error) {
+		calls++
+		// Return the same finished match each day; expect dedup to keep it once.
+		return []api.Match{
+			{ID: 100, Status: api.MatchStatusFinished},
+			{ID: 101, Status: api.MatchStatusFinished},
+			{ID: 200, Status: api.MatchStatusNotStarted}, // must be filtered
+		}, nil
+	}
+
+	matches, failed, err := collectFinished(context.Background(), fetch, now, 3)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if len(failed) != 0 {
+		t.Errorf("failedDates = %v, want empty", failed)
+	}
+	if calls != 3 {
+		t.Errorf("fetch called %d times, want 3", calls)
+	}
+	if len(matches) != 2 {
+		t.Errorf("returned %d matches, want 2 (dedup keeps 100,101; drops 200)", len(matches))
+	}
+	for _, m := range matches {
+		if m.Status != api.MatchStatusFinished {
+			t.Errorf("non-finished match leaked: %+v", m)
+		}
+	}
+}
+
+func TestCollectFinished_PartialFailureFlagsDegraded(t *testing.T) {
+	now := time.Date(2026, 6, 12, 12, 0, 0, 0, time.UTC)
+	callCount := 0
+	fetch := func(ctx context.Context, date time.Time, tabs []string) ([]api.Match, error) {
+		callCount++
+		if callCount == 2 {
+			return nil, errors.New("upstream blew up")
+		}
+		return []api.Match{
+			{ID: callCount, Status: api.MatchStatusFinished},
+		}, nil
+	}
+
+	matches, failed, err := collectFinished(context.Background(), fetch, now, 3)
+	if err != nil {
+		t.Fatalf("partial-success should not return err, got %v", err)
+	}
+	if len(failed) != 1 {
+		t.Errorf("failedDates = %v, want 1 entry", failed)
+	}
+	if len(matches) != 2 {
+		t.Errorf("matches len = %d, want 2", len(matches))
+	}
+}
+
+func TestCollectFinished_AllFailureReturnsError(t *testing.T) {
+	now := time.Date(2026, 6, 12, 12, 0, 0, 0, time.UTC)
+	fetch := func(ctx context.Context, date time.Time, tabs []string) ([]api.Match, error) {
+		return nil, errors.New("nope")
+	}
+
+	matches, failed, err := collectFinished(context.Background(), fetch, now, 2)
+	if err == nil {
+		t.Fatalf("expected err when all days fail")
+	}
+	if matches != nil {
+		t.Errorf("matches not nil on total failure: %v", matches)
+	}
+	if len(failed) != 2 {
+		t.Errorf("failedDates = %v, want 2", failed)
+	}
+}
+
+func TestCollectFinished_TodayUsesFixturesAndResults(t *testing.T) {
+	now := time.Date(2026, 6, 12, 12, 0, 0, 0, time.UTC)
+	gotTabs := [][]string{}
+	fetch := func(ctx context.Context, date time.Time, tabs []string) ([]api.Match, error) {
+		gotTabs = append(gotTabs, tabs)
+		return nil, nil
+	}
+
+	_, _, _ = collectFinished(context.Background(), fetch, now, 2)
+	if len(gotTabs) != 2 {
+		t.Fatalf("expected 2 fetches, got %d", len(gotTabs))
+	}
+	// Day 0 (today) → fixtures+results
+	if len(gotTabs[0]) != 2 {
+		t.Errorf("today tabs = %v, want fixtures+results", gotTabs[0])
+	}
+	// Day 1 → results only
+	if len(gotTabs[1]) != 1 || gotTabs[1][0] != "results" {
+		t.Errorf("past-day tabs = %v, want [results]", gotTabs[1])
+	}
+}

--- a/cmd/finished_test.go
+++ b/cmd/finished_test.go
@@ -155,3 +155,19 @@ func TestCollectFinished_TodayUsesFixturesAndResults(t *testing.T) {
 		t.Errorf("past-day tabs = %v, want [results]", gotTabs[1])
 	}
 }
+
+func TestRunFinished_TimeoutNotSwallowed(t *testing.T) {
+	t.Setenv(EnvOffline, "")
+	t.Setenv(EnvAgent, "")
+
+	// 1ns timeout — collectFinished may swallow per-day failures and return
+	// no error. The CLI must still report timeout to the agent.
+	var stdout, stderr bytes.Buffer
+	code := runFinished(&stdout, &stderr, finishedFlags{cliFlags: cliFlags{mock: false, timeout: 1}, days: 1})
+	if code != ExitTimeout {
+		t.Errorf("exit = %d, want %d (stderr=%s)", code, ExitTimeout, stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Errorf("stdout should be empty on timeout, got: %s", stdout.String())
+	}
+}

--- a/cmd/finished_test.go
+++ b/cmd/finished_test.go
@@ -71,7 +71,7 @@ func TestCollectFinished_DedupsByID(t *testing.T) {
 		}, nil
 	}
 
-	matches, failed, err := collectFinished(context.Background(), fetch, now, 3)
+	matches, failed, err := collectFinished(context.Background(), fetch, now, 3, false)
 	if err != nil {
 		t.Fatalf("err = %v", err)
 	}
@@ -104,7 +104,7 @@ func TestCollectFinished_PartialFailureFlagsDegraded(t *testing.T) {
 		}, nil
 	}
 
-	matches, failed, err := collectFinished(context.Background(), fetch, now, 3)
+	matches, failed, err := collectFinished(context.Background(), fetch, now, 3, false)
 	if err != nil {
 		t.Fatalf("partial-success should not return err, got %v", err)
 	}
@@ -122,7 +122,7 @@ func TestCollectFinished_AllFailureReturnsError(t *testing.T) {
 		return nil, errors.New("nope")
 	}
 
-	matches, failed, err := collectFinished(context.Background(), fetch, now, 2)
+	matches, failed, err := collectFinished(context.Background(), fetch, now, 2, false)
 	if err == nil {
 		t.Fatalf("expected err when all days fail")
 	}
@@ -142,7 +142,7 @@ func TestCollectFinished_TodayUsesFixturesAndResults(t *testing.T) {
 		return nil, nil
 	}
 
-	_, _, _ = collectFinished(context.Background(), fetch, now, 2)
+	_, _, _ = collectFinished(context.Background(), fetch, now, 2, false)
 	if len(gotTabs) != 2 {
 		t.Fatalf("expected 2 fetches, got %d", len(gotTabs))
 	}
@@ -169,5 +169,62 @@ func TestRunFinished_TimeoutNotSwallowed(t *testing.T) {
 	}
 	if stdout.Len() != 0 {
 		t.Errorf("stdout should be empty on timeout, got: %s", stdout.String())
+	}
+}
+
+func TestCollectFinished_IncludeUpcomingTodayOnly(t *testing.T) {
+	now := time.Date(2026, 6, 12, 12, 0, 0, 0, time.UTC)
+	fetch := func(ctx context.Context, date time.Time, tabs []string) ([]api.Match, error) {
+		// Same payload returned for every day: one finished, one not_started.
+		return []api.Match{
+			{ID: int(date.Unix()) + 1, Status: api.MatchStatusFinished},
+			{ID: int(date.Unix()) + 2, Status: api.MatchStatusNotStarted},
+		}, nil
+	}
+
+	// includeUpcoming=false → not_started filtered everywhere
+	matches, _, err := collectFinished(context.Background(), fetch, now, 2, false)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	for _, m := range matches {
+		if m.Status != api.MatchStatusFinished {
+			t.Errorf("include=false leaked status=%q match=%+v", m.Status, m)
+		}
+	}
+	if len(matches) != 2 {
+		t.Errorf("include=false count = %d, want 2 (finished from each day)", len(matches))
+	}
+
+	// includeUpcoming=true → today's not_started included, past-day not_started still filtered
+	matches, _, err = collectFinished(context.Background(), fetch, now, 2, true)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	statusCounts := map[api.MatchStatus]int{}
+	for _, m := range matches {
+		statusCounts[m.Status]++
+	}
+	if statusCounts[api.MatchStatusFinished] != 2 {
+		t.Errorf("finished count = %d, want 2", statusCounts[api.MatchStatusFinished])
+	}
+	if statusCounts[api.MatchStatusNotStarted] != 1 {
+		t.Errorf("not_started count = %d, want 1 (today only)", statusCounts[api.MatchStatusNotStarted])
+	}
+}
+
+func TestRunFinished_IncludeUpcomingFlag(t *testing.T) {
+	t.Setenv(EnvOffline, "")
+	t.Setenv(EnvAgent, "")
+
+	// Mock data is finished-only; the flag should not break mock execution.
+	var stdout, stderr bytes.Buffer
+	code := runFinished(&stdout, &stderr, finishedFlags{
+		cliFlags:        cliFlags{mock: true, timeout: time.Second},
+		days:            1,
+		includeUpcoming: true,
+	})
+	if code != ExitOK {
+		t.Fatalf("exit = %d, stderr=%s", code, stderr.String())
 	}
 }

--- a/cmd/leagues.go
+++ b/cmd/leagues.go
@@ -72,7 +72,10 @@ func runLeagues(stdout, stderr io.Writer, flags leaguesFlags) int {
 var leaguesCmd = &cobra.Command{
 	Use:           "leagues",
 	Short:         "List active (or all) supported leagues as JSON",
-	Long:          "Prints a JSON envelope listing currently active leagues (or all supported leagues with --all). No network calls. Useful for discovering league IDs to interpret live/finished results.",
+	Long: `Prints a JSON envelope listing currently active leagues (or all supported leagues with --all). No network calls. Useful for discovering league IDs to interpret live/finished results.
+
+Example output:
+  {"status":"ok","count":3,"data":[{"id":47,"name":"Premier League","country":"England","country_code":""},{"id":87,"name":"La Liga","country":"Spain","country_code":""},{"id":42,"name":"UEFA Champions League","country":"Europe","country_code":""}]}`,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/leagues.go
+++ b/cmd/leagues.go
@@ -1,0 +1,90 @@
+package cmd
+
+import (
+	"io"
+	"os"
+	"sort"
+
+	"github.com/0xjuanma/golazo/internal/api"
+	"github.com/0xjuanma/golazo/internal/data"
+	"github.com/spf13/cobra"
+)
+
+// leaguesFlags extends the common flag set with --all.
+type leaguesFlags struct {
+	cliFlags
+	all bool
+}
+
+var leaguesFlagSet leaguesFlags
+
+// resolveLeagues returns league metadata for either the active set (default)
+// or every supported league (--all). Output is sorted by ID for determinism.
+// Pure in-memory read of data.AllSupportedLeagues; no API call.
+func resolveLeagues(all bool) []api.League {
+	// Build an ID → LeagueInfo lookup over the full catalog.
+	catalog := make(map[int]data.LeagueInfo, 200)
+	for _, regionLeagues := range data.AllSupportedLeagues {
+		for _, info := range regionLeagues {
+			catalog[info.ID] = info
+		}
+	}
+
+	var ids []int
+	if all {
+		ids = make([]int, 0, len(catalog))
+		for id := range catalog {
+			ids = append(ids, id)
+		}
+	} else {
+		ids = append(ids, data.ActiveLeagueIDs()...)
+	}
+
+	sort.Ints(ids)
+
+	out := make([]api.League, 0, len(ids))
+	for _, id := range ids {
+		info, ok := catalog[id]
+		if !ok {
+			// User-selected ID we don't have metadata for; surface as bare ID.
+			out = append(out, api.League{ID: id})
+			continue
+		}
+		out = append(out, api.League{
+			ID:      info.ID,
+			Name:    info.Name,
+			Country: info.Country,
+		})
+	}
+	return out
+}
+
+// runLeagues is the testable core of the `leagues` subcommand.
+func runLeagues(stdout, stderr io.Writer, flags leaguesFlags) int {
+	applyPretty(flags.cliFlags)
+	leagues := resolveLeagues(flags.all)
+	if err := WriteJSON(stdout, leagues); err != nil {
+		return WriteError(stderr, ErrCodeUpstreamError, err)
+	}
+	return ExitOK
+}
+
+var leaguesCmd = &cobra.Command{
+	Use:           "leagues",
+	Short:         "List active (or all) supported leagues as JSON",
+	Long:          "Prints a JSON envelope listing currently active leagues (or all supported leagues with --all). No network calls. Useful for discovering league IDs to interpret live/finished results.",
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	Run: func(cmd *cobra.Command, args []string) {
+		code := runLeagues(os.Stdout, os.Stderr, leaguesFlagSet)
+		if code != ExitOK {
+			os.Exit(code)
+		}
+	},
+}
+
+func init() {
+	addCommonCLIFlags(leaguesCmd, &leaguesFlagSet.cliFlags)
+	leaguesCmd.Flags().BoolVar(&leaguesFlagSet.all, "all", false, "List every supported league, not just the active selection")
+	rootCmd.AddCommand(leaguesCmd)
+}

--- a/cmd/leagues.go
+++ b/cmd/leagues.go
@@ -87,7 +87,7 @@ Example output:
 }
 
 func init() {
-	addCommonCLIFlags(leaguesCmd, &leaguesFlagSet.cliFlags)
+	addPrettyOnlyFlag(leaguesCmd, &leaguesFlagSet.cliFlags)
 	leaguesCmd.Flags().BoolVar(&leaguesFlagSet.all, "all", false, "List every supported league, not just the active selection")
 	rootCmd.AddCommand(leaguesCmd)
 }

--- a/cmd/leagues_test.go
+++ b/cmd/leagues_test.go
@@ -1,0 +1,90 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"slices"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/0xjuanma/golazo/internal/api"
+	"github.com/0xjuanma/golazo/internal/data"
+)
+
+func TestResolveLeagues_DefaultsToActive(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	got := resolveLeagues(false)
+
+	gotIDs := make([]int, len(got))
+	for i, l := range got {
+		gotIDs[i] = l.ID
+	}
+
+	wantIDs := append([]int(nil), data.DefaultLeagueIDs...)
+	sort.Ints(wantIDs)
+
+	if !slices.Equal(gotIDs, wantIDs) {
+		t.Errorf("got IDs=%v, want %v", gotIDs, wantIDs)
+	}
+}
+
+func TestResolveLeagues_AllListsEverySupportedLeague(t *testing.T) {
+	got := resolveLeagues(true)
+	if len(got) != len(data.AllLeagueIDs()) {
+		t.Errorf("len = %d, want %d", len(got), len(data.AllLeagueIDs()))
+	}
+	// Verify sorted by ID for determinism.
+	for i := 1; i < len(got); i++ {
+		if got[i-1].ID > got[i].ID {
+			t.Errorf("unsorted at %d: %d > %d", i, got[i-1].ID, got[i].ID)
+		}
+	}
+}
+
+func TestResolveLeagues_EnrichesNameAndCountry(t *testing.T) {
+	got := resolveLeagues(true)
+	// Premier League (47) must be present with name+country.
+	var pl *api.League
+	for i := range got {
+		if got[i].ID == 47 {
+			pl = &got[i]
+			break
+		}
+	}
+	if pl == nil {
+		t.Fatalf("Premier League (47) not in result")
+	}
+	if pl.Name == "" || pl.Country == "" {
+		t.Errorf("missing enrichment: %+v", *pl)
+	}
+}
+
+func TestRunLeagues_EmitsEnvelope(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	var stdout, stderr bytes.Buffer
+	code := runLeagues(&stdout, &stderr, leaguesFlags{cliFlags: cliFlags{timeout: time.Second}})
+	if code != ExitOK {
+		t.Fatalf("exit = %d, stderr=%s", code, stderr.String())
+	}
+	var env struct {
+		Status string       `json:"status"`
+		Count  int          `json:"count"`
+		Data   []api.League `json:"data"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal: %v\nraw: %s", err, stdout.String())
+	}
+	if env.Status != "ok" {
+		t.Errorf("status = %q", env.Status)
+	}
+	if env.Count != len(data.DefaultLeagueIDs) {
+		t.Errorf("count = %d, want %d", env.Count, len(data.DefaultLeagueIDs))
+	}
+}

--- a/cmd/live.go
+++ b/cmd/live.go
@@ -97,7 +97,10 @@ var liveFlags cliFlags
 var liveCmd = &cobra.Command{
 	Use:           "live",
 	Short:         "List live matches as JSON",
-	Long:          "Fetches today's live matches for the active leagues and prints a JSON envelope to stdout.",
+	Long: `Fetches today's live matches for the active leagues and prints a JSON envelope to stdout.
+
+Example output:
+  {"status":"ok","count":1,"data":[{"id":4506424,"league":{"id":47,"name":"Premier League","country":"England"},"home_team":{"id":8455,"name":"Chelsea","short_name":"Chelsea"},"away_team":{"id":6,"name":"Tottenham","short_name":"Spurs"},"status":"live","home_score":2,"away_score":1,"match_time":"2026-06-12T19:00:00Z","live_time":"67'","round":"Matchday 17"}]}`,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/live.go
+++ b/cmd/live.go
@@ -1,0 +1,105 @@
+package cmd
+
+import (
+	"context"
+	"io"
+	"os"
+	"time"
+
+	"github.com/0xjuanma/golazo/internal/api"
+	"github.com/0xjuanma/golazo/internal/data"
+	"github.com/0xjuanma/golazo/internal/fotmob"
+	"github.com/spf13/cobra"
+)
+
+// Common per-subcommand flag values. Each subcommand declares its own copies
+// so the TUI's rootCmd flag set stays untouched.
+type cliFlags struct {
+	mock    bool
+	debug   bool
+	timeout time.Duration
+	pretty  bool
+}
+
+// addCommonCLIFlags registers --mock, --debug, --timeout, --pretty on a subcmd.
+func addCommonCLIFlags(cmd *cobra.Command, f *cliFlags) {
+	cmd.Flags().BoolVar(&f.mock, "mock", false, "Use mock data instead of real API")
+	cmd.Flags().BoolVar(&f.debug, "debug", false, "Emit debug logs to stderr")
+	cmd.Flags().DurationVar(&f.timeout, "timeout", 15*time.Second, "Overall request timeout")
+	cmd.Flags().BoolVar(&f.pretty, "pretty", false, "Indent JSON output")
+}
+
+// applyPretty syncs the package-level Pretty toggle. Subcommands call this
+// from RunE before emitting output. GOLAZO_AGENT forces compact regardless.
+func applyPretty(f cliFlags) {
+	if agentMode() {
+		Pretty = false
+		return
+	}
+	Pretty = f.pretty
+}
+
+// liveFetcher abstracts the live-matches data source so runLive can be tested
+// without spinning up an HTTP client. The default implementation calls into
+// fotmob.Client; mock-mode callers bypass it entirely.
+type liveFetcher func(ctx context.Context) ([]api.Match, error)
+
+func defaultLiveFetcher(c *fotmob.Client) liveFetcher {
+	return c.LiveMatches
+}
+
+// runLive is the testable core of the `live` subcommand. It writes the JSON
+// envelope to stdout and any error envelope to stderr; returns the exit code.
+func runLive(stdout, stderr io.Writer, flags cliFlags) int {
+	applyPretty(flags)
+
+	client, ctx, cancel, err := newHeadlessClient(runtimeOpts{
+		mock:    flags.mock,
+		debug:   flags.debug,
+		timeout: flags.timeout,
+	})
+	defer cancel()
+	if err == ErrOffline {
+		return WriteError(stderr, ErrCodeOffline, err)
+	}
+	if err != nil {
+		return WriteError(stderr, ErrCodeUpstreamError, err)
+	}
+
+	var matches []api.Match
+	if flags.mock {
+		matches = data.MockLiveMatches()
+	} else {
+		matches, err = defaultLiveFetcher(client)(ctx)
+		if err != nil {
+			return WriteError(stderr, ClassifyClientError(err, isTimeout(ctx)), err)
+		}
+	}
+
+	SortMatches(matches)
+	if err := WriteJSON(stdout, matches); err != nil {
+		return WriteError(stderr, ErrCodeUpstreamError, err)
+	}
+	return ExitOK
+}
+
+var liveFlags cliFlags
+
+var liveCmd = &cobra.Command{
+	Use:           "live",
+	Short:         "List live matches as JSON",
+	Long:          "Fetches today's live matches for the active leagues and prints a JSON envelope to stdout.",
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	Run: func(cmd *cobra.Command, args []string) {
+		code := runLive(os.Stdout, os.Stderr, liveFlags)
+		if code != ExitOK {
+			os.Exit(code)
+		}
+	},
+}
+
+func init() {
+	addCommonCLIFlags(liveCmd, &liveFlags)
+	rootCmd.AddCommand(liveCmd)
+}

--- a/cmd/live.go
+++ b/cmd/live.go
@@ -30,6 +30,13 @@ func addCommonCLIFlags(cmd *cobra.Command, f *cliFlags) {
 	cmd.Flags().BoolVar(&f.pretty, "pretty", false, "Indent JSON output")
 }
 
+// addPrettyOnlyFlag registers only --pretty. Used by subcommands that perform
+// no network I/O (leagues, capabilities), so --mock/--debug/--timeout would be
+// inert and confuse agents reading the capabilities contract.
+func addPrettyOnlyFlag(cmd *cobra.Command, f *cliFlags) {
+	cmd.Flags().BoolVar(&f.pretty, "pretty", false, "Indent JSON output")
+}
+
 // applyPretty syncs the package-level Pretty toggle. Subcommands call this
 // from RunE before emitting output. GOLAZO_AGENT forces compact regardless.
 func applyPretty(f cliFlags) {

--- a/cmd/live.go
+++ b/cmd/live.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"time"
@@ -73,6 +74,14 @@ func runLive(stdout, stderr io.Writer, flags cliFlags) int {
 		matches, err = defaultLiveFetcher(client)(ctx)
 		if err != nil {
 			return WriteError(stderr, ClassifyClientError(err, isTimeout(ctx)), err)
+		}
+		// Guard against silent timeouts: the underlying client aggregates
+		// per-league fetches and returns nil/empty when all goroutines fail
+		// due to context cancellation. Agents must be able to distinguish
+		// "no live matches" from "timed out".
+		if isTimeout(ctx) {
+			return WriteError(stderr, ErrCodeTimeout,
+				fmt.Errorf("live matches fetch timed out after %s", flags.timeout))
 		}
 	}
 

--- a/cmd/live_test.go
+++ b/cmd/live_test.go
@@ -1,0 +1,92 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/0xjuanma/golazo/internal/api"
+	"github.com/0xjuanma/golazo/internal/data"
+)
+
+func TestRunLive_MockReturnsEnvelopeWithExpectedCount(t *testing.T) {
+	t.Setenv(EnvOffline, "")
+	t.Setenv(EnvAgent, "")
+
+	var stdout, stderr bytes.Buffer
+	code := runLive(&stdout, &stderr, cliFlags{mock: true, timeout: 5 * time.Second})
+
+	if code != ExitOK {
+		t.Fatalf("exit code = %d, want %d. stderr=%s", code, ExitOK, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("stderr not empty: %s", stderr.String())
+	}
+
+	var env struct {
+		Status string      `json:"status"`
+		Count  int         `json:"count"`
+		Data   []api.Match `json:"data"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal stdout: %v\nraw: %s", err, stdout.String())
+	}
+	if env.Status != "ok" {
+		t.Errorf("status = %q", env.Status)
+	}
+	want := len(data.MockLiveMatches())
+	if env.Count != want {
+		t.Errorf("count = %d, want %d", env.Count, want)
+	}
+	if len(env.Data) != want {
+		t.Errorf("data length = %d, want %d", len(env.Data), want)
+	}
+}
+
+func TestRunLive_OfflineEnvWritesErrorToStderr(t *testing.T) {
+	t.Setenv(EnvOffline, "1")
+
+	var stdout, stderr bytes.Buffer
+	code := runLive(&stdout, &stderr, cliFlags{mock: false, timeout: time.Second})
+
+	if code != ExitOffline {
+		t.Errorf("exit code = %d, want %d", code, ExitOffline)
+	}
+	if stdout.Len() != 0 {
+		t.Errorf("stdout should be empty on error, got: %s", stdout.String())
+	}
+	var env errEnvelope
+	if err := json.Unmarshal(stderr.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal stderr: %v\nraw: %s", err, stderr.String())
+	}
+	if env.Code != ErrCodeOffline {
+		t.Errorf("error code = %q, want %q", env.Code, ErrCodeOffline)
+	}
+}
+
+func TestRunLive_MockWorksUnderOffline(t *testing.T) {
+	t.Setenv(EnvOffline, "1")
+
+	var stdout, stderr bytes.Buffer
+	code := runLive(&stdout, &stderr, cliFlags{mock: true, timeout: time.Second})
+
+	if code != ExitOK {
+		t.Errorf("exit code = %d, want %d (offline+mock should succeed)", code, ExitOK)
+	}
+	if stdout.Len() == 0 {
+		t.Errorf("stdout empty under offline+mock")
+	}
+}
+
+func TestRunLive_AgentModeForcesCompact(t *testing.T) {
+	t.Setenv(EnvAgent, "1")
+	defer func() { Pretty = false }()
+
+	var stdout, stderr bytes.Buffer
+	_ = runLive(&stdout, &stderr, cliFlags{mock: true, pretty: true, timeout: time.Second})
+
+	if bytes.Contains(stdout.Bytes(), []byte("\n  ")) {
+		t.Errorf("agent mode should force compact, got indented: %s", stdout.String())
+	}
+}

--- a/cmd/live_test.go
+++ b/cmd/live_test.go
@@ -90,3 +90,20 @@ func TestRunLive_AgentModeForcesCompact(t *testing.T) {
 		t.Errorf("agent mode should force compact, got indented: %s", stdout.String())
 	}
 }
+
+func TestRunLive_TimeoutNotSwallowed(t *testing.T) {
+	t.Setenv(EnvOffline, "")
+	t.Setenv(EnvAgent, "")
+
+	// 1ns timeout — the headless client's context is deadline-exceeded
+	// immediately. The underlying LiveMatches aggregator may return an
+	// empty slice with nil error; the CLI must still report timeout.
+	var stdout, stderr bytes.Buffer
+	code := runLive(&stdout, &stderr, cliFlags{mock: false, timeout: 1})
+	if code != ExitTimeout {
+		t.Errorf("exit = %d, want %d (stderr=%s, stdout=%s)", code, ExitTimeout, stderr.String(), stdout.String())
+	}
+	if stdout.Len() != 0 {
+		t.Errorf("stdout should be empty on timeout, got: %s", stdout.String())
+	}
+}

--- a/cmd/match.go
+++ b/cmd/match.go
@@ -73,7 +73,13 @@ func runMatch(stdout, stderr io.Writer, flags cliFlags, args []string) int {
 var matchCmd = &cobra.Command{
 	Use:           "match <id>",
 	Short:         "Get match details as JSON",
-	Long:          "Fetches detailed information (events, lineups, stats, formations) for a single match by ID and prints a JSON envelope to stdout.",
+	Long: `Fetches detailed information (events, lineups, stats, formations) for a single match by ID and prints a JSON envelope to stdout.
+
+IMPORTANT: cold-calling 'golazo match <id>' with an arbitrary ID is unreliable — FotMob's details endpoint requires a page slug only populated by a prior 'live' or 'finished' call in the same process. Use the chained pattern instead:
+  golazo finished | jq -r '.data[0].id' | xargs golazo match
+
+Example output (truncated):
+  {"status":"ok","count":1,"data":[{"id":4506420,"home_team":{"name":"Liverpool"},"away_team":{"name":"Arsenal"},"status":"finished","home_score":3,"away_score":1,"events":[{"minute":12,"type":"goal","player":"Salah","team":{"name":"Liverpool"}}],"statistics":[{"key":"possession","label":"Possession","home_value":"58%","away_value":"42%"}],"venue":"Anfield"}]}`,
 	Args:          cobra.ArbitraryArgs, // validated in runMatch for precise error envelope
 	SilenceUsage:  true,
 	SilenceErrors: true,

--- a/cmd/match.go
+++ b/cmd/match.go
@@ -72,14 +72,22 @@ func runMatch(stdout, stderr io.Writer, flags cliFlags, args []string) int {
 
 var matchCmd = &cobra.Command{
 	Use:           "match <id>",
-	Short:         "Get match details as JSON",
-	Long: `Fetches detailed information (events, lineups, stats, formations) for a single match by ID and prints a JSON envelope to stdout.
+	Short:         "Get match details as JSON (best-effort; see notes)",
+	Long: `Fetches detailed information (events, lineups, stats, formations) for a single match by ID.
 
-IMPORTANT: cold-calling 'golazo match <id>' with an arbitrary ID is unreliable — FotMob's details endpoint requires a page slug only populated by a prior 'live' or 'finished' call in the same process. Use the chained pattern instead:
-  golazo finished | jq -r '.data[0].id' | xargs golazo match
+LIMITATION: This subcommand is BEST-EFFORT only. FotMob's match-details endpoint is gated behind Cloudflare and requires a page slug that this CLI cannot reliably obtain in a one-shot invocation. Cold calls with arbitrary IDs typically return upstream_error (HTTP 404), even for valid IDs returned by 'live' or 'finished' in a separate process.
+
+Reliable usage:
+  - With --mock: works against bundled mock IDs (e.g. 2001, 2002)
+  - From inside the TUI: 'golazo' (interactive) reliably loads match details
+
+Not recommended for production agent pipelines. Agents that need event-level data should rely on the 'live' and 'finished' subcommands, which return match metadata, scores, status, and round info without this constraint.
+
+Example (mock):
+  golazo match 2001 --mock
 
 Example output (truncated):
-  {"status":"ok","count":1,"data":[{"id":4506420,"home_team":{"name":"Liverpool"},"away_team":{"name":"Arsenal"},"status":"finished","home_score":3,"away_score":1,"events":[{"minute":12,"type":"goal","player":"Salah","team":{"name":"Liverpool"}}],"statistics":[{"key":"possession","label":"Possession","home_value":"58%","away_value":"42%"}],"venue":"Anfield"}]}`,
+  {"status":"ok","count":1,"data":[{"id":2001,"home_team":{"name":"Chelsea"},"away_team":{"name":"Tottenham"},"status":"live","home_score":2,"away_score":1,"events":[{"minute":12,"type":"goal","player":"Palmer","team":{"name":"Chelsea"}}],"statistics":[{"key":"possession","label":"Possession","home_value":"58%","away_value":"42%"}],"venue":"Stamford Bridge"}]}`,
 	Args:          cobra.ArbitraryArgs, // validated in runMatch for precise error envelope
 	SilenceUsage:  true,
 	SilenceErrors: true,

--- a/cmd/match.go
+++ b/cmd/match.go
@@ -1,0 +1,91 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+
+	"github.com/0xjuanma/golazo/internal/api"
+	"github.com/0xjuanma/golazo/internal/data"
+	"github.com/0xjuanma/golazo/internal/fotmob"
+	"github.com/spf13/cobra"
+)
+
+type matchDetailsFetcher func(ctx context.Context, matchID int) (*api.MatchDetails, error)
+
+func defaultMatchDetailsFetcher(c *fotmob.Client) matchDetailsFetcher {
+	return c.MatchDetails
+}
+
+var matchFlagSet cliFlags
+
+// runMatch is the testable core of the `match` subcommand.
+// args is the positional arg slice from cobra (we expect exactly one ID).
+func runMatch(stdout, stderr io.Writer, flags cliFlags, args []string) int {
+	applyPretty(flags)
+
+	if len(args) != 1 {
+		return WriteError(stderr, ErrCodeInvalidArgs,
+			NewInvalidArg("expected exactly one match id, got %d args", len(args)))
+	}
+	id, err := strconv.Atoi(args[0])
+	if err != nil || id <= 0 {
+		return WriteError(stderr, ErrCodeInvalidArgs,
+			NewInvalidArg("match id must be a positive integer, got %q", args[0]))
+	}
+
+	client, ctx, cancel, err := newHeadlessClient(runtimeOpts{
+		mock:    flags.mock,
+		debug:   flags.debug,
+		timeout: flags.timeout,
+	})
+	defer cancel()
+	if err == ErrOffline {
+		return WriteError(stderr, ErrCodeOffline, err)
+	}
+	if err != nil {
+		return WriteError(stderr, ErrCodeUpstreamError, err)
+	}
+
+	var (
+		details *api.MatchDetails
+	)
+	if flags.mock {
+		details, err = data.MockMatchDetails(id)
+	} else {
+		details, err = defaultMatchDetailsFetcher(client)(ctx, id)
+	}
+	if err != nil {
+		return WriteError(stderr, ClassifyClientError(err, isTimeout(ctx)), err)
+	}
+	if details == nil {
+		return WriteError(stderr, ErrCodeNotFound, fmt.Errorf("no match found for id %d", id))
+	}
+
+	if err := WriteJSON(stdout, []api.MatchDetails{*details}); err != nil {
+		return WriteError(stderr, ErrCodeUpstreamError, err)
+	}
+	return ExitOK
+}
+
+var matchCmd = &cobra.Command{
+	Use:           "match <id>",
+	Short:         "Get match details as JSON",
+	Long:          "Fetches detailed information (events, lineups, stats, formations) for a single match by ID and prints a JSON envelope to stdout.",
+	Args:          cobra.ArbitraryArgs, // validated in runMatch for precise error envelope
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	Run: func(cmd *cobra.Command, args []string) {
+		code := runMatch(os.Stdout, os.Stderr, matchFlagSet, args)
+		if code != ExitOK {
+			os.Exit(code)
+		}
+	},
+}
+
+func init() {
+	addCommonCLIFlags(matchCmd, &matchFlagSet)
+	rootCmd.AddCommand(matchCmd)
+}

--- a/cmd/match_test.go
+++ b/cmd/match_test.go
@@ -1,0 +1,76 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/0xjuanma/golazo/internal/api"
+)
+
+func TestRunMatch_MissingArg(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := runMatch(&stdout, &stderr, cliFlags{mock: true, timeout: time.Second}, nil)
+	if code != ExitInvalidArgs {
+		t.Errorf("exit = %d, want %d", code, ExitInvalidArgs)
+	}
+	var env errEnvelope
+	if err := json.Unmarshal(stderr.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal stderr: %v", err)
+	}
+	if env.Code != ErrCodeInvalidArgs {
+		t.Errorf("code = %q, want %q", env.Code, ErrCodeInvalidArgs)
+	}
+}
+
+func TestRunMatch_InvalidID(t *testing.T) {
+	cases := []string{"abc", "0", "-1", ""}
+	for _, arg := range cases {
+		t.Run(arg, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code := runMatch(&stdout, &stderr, cliFlags{mock: true, timeout: time.Second}, []string{arg})
+			if code != ExitInvalidArgs {
+				t.Errorf("arg=%q exit = %d, want %d", arg, code, ExitInvalidArgs)
+			}
+		})
+	}
+}
+
+func TestRunMatch_MockUnknownIDReturnsNotFound(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := runMatch(&stdout, &stderr, cliFlags{mock: true, timeout: time.Second}, []string{"99999999"})
+	if code != ExitNotFound {
+		t.Errorf("exit = %d, want %d", code, ExitNotFound)
+	}
+	var env errEnvelope
+	if err := json.Unmarshal(stderr.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal stderr: %v", err)
+	}
+	if env.Code != ErrCodeNotFound {
+		t.Errorf("code = %q, want %q", env.Code, ErrCodeNotFound)
+	}
+}
+
+func TestRunMatch_MockKnownIDReturnsDetails(t *testing.T) {
+	// 2001 is the first mock live match ID (see internal/data/mock_live_matches.go).
+	var stdout, stderr bytes.Buffer
+	code := runMatch(&stdout, &stderr, cliFlags{mock: true, timeout: time.Second}, []string{"2001"})
+	if code != ExitOK {
+		t.Fatalf("exit = %d, want %d. stderr=%s", code, ExitOK, stderr.String())
+	}
+	var env struct {
+		Status string             `json:"status"`
+		Count  int                `json:"count"`
+		Data   []api.MatchDetails `json:"data"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal: %v\nraw: %s", err, stdout.String())
+	}
+	if env.Count != 1 || len(env.Data) != 1 {
+		t.Fatalf("expected count=1 and one entry, got count=%d len=%d", env.Count, len(env.Data))
+	}
+	if env.Data[0].ID != 2001 {
+		t.Errorf("data[0].ID = %d, want 2001", env.Data[0].ID)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,6 +27,10 @@ var rootCmd = &cobra.Command{
 	Use:   "golazo",
 	Short: "The beautiful game in your terminal",
 	Long:  `A minimal TUI for following football matches in real-time. Get live match updates, finished match statistics, and minute-by-minute events directly in your terminal.`,
+	// Suppress cobra's default plain-text error printing so we can wrap
+	// flag/subcommand errors in the agent-facing JSON envelope (see Execute).
+	SilenceErrors: true,
+	SilenceUsage:  true,
 	Run: func(cmd *cobra.Command, args []string) {
 		if versionFlag {
 			version.Print(Version)
@@ -215,11 +219,15 @@ func isListedInBrew() bool {
 }
 
 // Execute runs the root command.
-// Errors are written to stderr and the program exits with code 1 on failure.
+//
+// All subcommands call os.Exit() directly with the documented exit codes,
+// so any error reaching here is a cobra-level parse failure (unknown command,
+// unknown flag, invalid value). We surface those through the same JSON
+// envelope used by every other CLI failure so agents can rely on a single
+// error contract.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(1)
+		os.Exit(WriteError(os.Stderr, ErrCodeInvalidArgs, err))
 	}
 }
 

--- a/cmd/root_envelope_test.go
+++ b/cmd/root_envelope_test.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// TestExecute_UnknownCommandEnveloped verifies that cobra's "unknown command"
+// errors reach the JSON envelope rather than printing plain text. This is the
+// contract Issue 3 fixes: agents that parse stderr as JSON shouldn't crash on
+// a typo'd subcommand.
+//
+// We can't exec the binary here, but we can exercise the same envelope path
+// the Execute() wrapper uses.
+func TestExecute_UnknownCommandEnvelopedAsInvalidArgs(t *testing.T) {
+	// Build a throwaway cobra root with one subcommand so we can synthesize
+	// the same error type that the real rootCmd would return.
+	root := &cobra.Command{Use: "golazo", SilenceErrors: true, SilenceUsage: true}
+	root.AddCommand(&cobra.Command{Use: "live", Run: func(cmd *cobra.Command, args []string) {}})
+	root.SetArgs([]string{"bogus"})
+
+	var cobraOut bytes.Buffer
+	root.SetOut(&cobraOut)
+	root.SetErr(&cobraOut)
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatalf("expected error from unknown subcommand")
+	}
+
+	// This is what Execute() does in production.
+	var envBuf bytes.Buffer
+	exit := WriteError(&envBuf, ErrCodeInvalidArgs, err)
+	if exit != ExitInvalidArgs {
+		t.Errorf("exit = %d, want %d", exit, ExitInvalidArgs)
+	}
+	var env errEnvelope
+	if jerr := json.Unmarshal(envBuf.Bytes(), &env); jerr != nil {
+		t.Fatalf("envelope not valid JSON: %v\nraw: %s", jerr, envBuf.String())
+	}
+	if env.Code != ErrCodeInvalidArgs {
+		t.Errorf("code = %q, want %q", env.Code, ErrCodeInvalidArgs)
+	}
+	if env.Message == "" {
+		t.Errorf("message empty; agents need a useful description")
+	}
+}
+
+func TestExecute_FlagErrorEnveloped(t *testing.T) {
+	// Sanity: a synthetic flag-parse error follows the same path.
+	err := errors.New("unknown flag: --foo")
+	var envBuf bytes.Buffer
+	exit := WriteError(&envBuf, ErrCodeInvalidArgs, err)
+	if exit != ExitInvalidArgs {
+		t.Errorf("exit = %d, want %d", exit, ExitInvalidArgs)
+	}
+	if !bytes.Contains(envBuf.Bytes(), []byte("unknown flag")) {
+		t.Errorf("envelope missing original error: %s", envBuf.String())
+	}
+}

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -24,6 +24,9 @@ If the user's question doesn't map to one of the above, this tool likely cannot 
 The canonical agent flow is **discover → list → drill in**. Every reliable use of `match <id>` first pulls the ID from a list call in the same pipeline:
 
 ```bash
+# 0. (Optional but recommended) Self-discover the CLI contract
+golazo capabilities | jq '.data[0].commands'
+
 # 1. Discover which competitions are active
 golazo leagues
 
@@ -51,6 +54,7 @@ This pattern keeps the in-process page-slug cache populated, which is what makes
 | `golazo finished [--days N] [--include-upcoming]` | Finished matches over the last N days (1..7, default 1); use `--include-upcoming` to also include today's not-yet-started matches |
 | `golazo match <id>` | Full match details (events, lineups, stats) |
 | `golazo leagues [--all]` | Active leagues (or every supported league) |
+| `golazo capabilities` | Machine-readable contract describing every subcommand, flag, error code and env var — call this once at session start to self-discover the CLI |
 
 ### Common flags
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,0 +1,111 @@
+# CLI / Agent Mode
+
+Golazo ships with a small set of subcommands that emit JSON to stdout. They are intended for agents (Claude Code, scripts, CI) that need structured match data without driving the TUI.
+
+The default `golazo` invocation still opens the TUI — the subcommands below are additive.
+
+## Subcommands
+
+| Command | Description |
+|---|---|
+| `golazo live` | Live matches across active leagues |
+| `golazo finished [--days N]` | Finished matches over the last N days (1..7, default 1) |
+| `golazo match <id>` | Full match details (events, lineups, stats) |
+| `golazo leagues [--all]` | Active leagues (or every supported league) |
+
+### Common flags
+
+| Flag | Description |
+|---|---|
+| `--mock` | Use bundled mock data, no network |
+| `--debug` | Emit debug logs to stderr |
+| `--timeout <dur>` | Overall request timeout (default `15s`) |
+| `--pretty` | Indent JSON output |
+
+## JSON contract
+
+### Success envelope
+
+```json
+{
+  "status": "ok",
+  "count": 2,
+  "data": [ ... ]
+}
+```
+
+Single-item responses (e.g. `match <id>`) still use a `data` array with `count: 1`.
+
+### Degraded envelope
+
+`finished` over multiple days may partially fail. When at least one day succeeds, the envelope is flagged degraded with the failing dates listed:
+
+```json
+{
+  "status": "ok",
+  "degraded": true,
+  "failed_dates": ["2026-06-10"],
+  "count": 12,
+  "data": [ ... ]
+}
+```
+
+### Error envelope
+
+Errors go to **stderr**, stdout stays empty:
+
+```json
+{
+  "status": "error",
+  "code": "not_found",
+  "message": "no match found for id 99999999"
+}
+```
+
+Error codes: `invalid_args`, `not_found`, `upstream_error`, `timeout`, `offline`.
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Success |
+| `1` | Upstream / unknown error |
+| `2` | Invalid arguments |
+| `3` | Not found |
+| `4` | Timeout |
+| `5` | Offline (network disabled via env) |
+
+## Environment variables
+
+| Var | Effect |
+|---|---|
+| `GOLAZO_AGENT=1` | Forces compact JSON, enables stderr debug logging |
+| `GOLAZO_OFFLINE=1` | Refuses any network call; subcommands return `offline` unless `--mock` is set |
+
+## Examples
+
+```bash
+# Live matches, compact JSON
+golazo live
+
+# Finished matches over the last 3 days, indented
+golazo finished --days 3 --pretty
+
+# Single match details
+golazo match 4506424
+
+# Discover league IDs to interpret results
+golazo leagues --all
+
+# Pipe through jq
+golazo live | jq '.data[] | {home: .home_team.name, away: .away_team.name, score: "\(.home_score)-\(.away_score)"}'
+
+# Agent mode + offline safety in CI
+GOLAZO_AGENT=1 GOLAZO_OFFLINE=1 golazo live --mock
+```
+
+## Notes
+
+- Stdout receives **only** the JSON envelope. All logs go to stderr — safe to pipe through `jq`.
+- List output is sorted deterministically (`match_time` then `id`) so repeated invocations diff cleanly.
+- The TUI experience is unchanged — no flags here alter the interactive default.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -48,6 +48,8 @@ This pattern keeps the in-process page-slug cache populated, which is what makes
 
 ## Subcommands
 
+> **⚠ Important for agents using `match <id>`:** cold-calling this command with an arbitrary ID is unreliable and will most likely return `upstream_error`. FotMob's details endpoint requires a page slug only populated by a prior `live` or `finished` call in the same process. **Always chain**: `golazo finished | jq -r '.data[0].id' | xargs golazo match`. See [Known limitations](#known-limitations) for the full explanation.
+
 | Command | Description |
 |---|---|
 | `golazo live` | Live matches across active leagues |
@@ -260,7 +262,38 @@ golazo finished | jq -r '.data[0].id' | xargs golazo match \
 - List output is sorted deterministically (`match_time` then `id`) so repeated invocations diff cleanly.
 - The TUI experience is unchanged — no flags here alter the interactive default.
 
-## Known limitations
+## Failure modes & retry policy
+
+Use this table to decide whether to retry, fix the call, or give up.
+
+| Error code | Exit | Typical cause | Should agent retry? |
+|---|---|---|---|
+| `invalid_args` | `2` | Bad flag value (e.g. `--days 99`, non-numeric match ID) | **No** — fix the call. Retrying will keep failing. |
+| `not_found` | `3` | Unknown match ID (mock mode), or match has no data | **No** — pick a fresh ID via a list call. |
+| `timeout` | `4` | Upstream slow or network congested | **Yes**, with a larger `--timeout` (e.g. `--timeout 30s`). |
+| `upstream_error` | `1` | FotMob 4xx/5xx, network failure, Cloudflare challenge | **Once** — transient errors recover. If the same ID keeps failing on `match`, see the slug-cache note in [Known limitations](#known-limitations). |
+| `offline` | `5` | `GOLAZO_OFFLINE=1` is set | **No** — unset the env var, or pass `--mock` for synthetic data. |
+
+The exit code is the most reliable retry signal. The `code` field in the error envelope on stderr says the same thing in machine-readable form; agents should prefer the exit code (no JSON parsing required).
+
+## "No matches" vs "failure" semantics
+
+Two outputs look superficially similar but mean very different things:
+
+```json
+{"status":"ok","count":0,"data":[]}            // success, just nothing today
+{"status":"error","code":"upstream_error",...} // failure on stderr, exit 1
+```
+
+A `count: 0` result means **the request succeeded and there genuinely are no matches** matching the criteria (off-season, no World Cup games today, no live matches at 4am, etc.). It is **not** a silent failure. Do not retry on `count: 0` — you will get the same answer.
+
+Conversely, partial failures (`finished` over multiple days where some days fetched and others didn't) are surfaced as `degraded: true` with a `failed_dates` array — those are still exit code 0, but agents can choose to retry just the failed dates.
+
+## Rate limiting
+
+Golazo internally rate-limits FotMob requests to one every 200ms and caps concurrent requests at 10. Agents calling subcommands in tight loops will not be rejected — requests just queue. There is **no** explicit `rate_limited` error code today. If FotMob itself rate-limits the underlying client, that surfaces as `upstream_error`.
+
+
 
 ### `match <id>` requires IDs from a prior list call
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -14,14 +14,14 @@ Use this tool when the user asks about football (soccer) matches. Map their ques
 | Today's results (already finished) | `golazo finished --days 1` |
 | Today's full slate (finished + still-to-come) | `golazo finished --include-upcoming` |
 | Results over the last N days (≤7) | `golazo finished --days N` |
-| Details for a specific match (events, lineups, stats) | `golazo match <id>` — see [Known limitations](#known-limitations) |
+| Details for a specific match (events, lineups, stats) | `golazo match <id>` — **best-effort only**, see [Known limitations](#known-limitations) |
 | Which competitions are tracked / what league IDs exist | `golazo leagues` (or `--all`) |
 
 If the user's question doesn't map to one of the above, this tool likely cannot answer it. Golazo does not expose: standings/tables, head-to-head history, individual player stats, transfer news, or fixtures beyond today.
 
 ## Quick start (worked example)
 
-The canonical agent flow is **discover → list → drill in**. Every reliable use of `match <id>` first pulls the ID from a list call in the same pipeline:
+The reliable agent flow is **discover → list**. Stop at the list level — `live` and `finished` already return all the per-match metadata an agent typically needs (teams, score, status, kickoff time, league). Drilling into `match <id>` is best-effort only and not recommended for one-shot pipelines (see [Known limitations](#known-limitations)).
 
 ```bash
 # 0. (Optional but recommended) Self-discover the CLI contract
@@ -30,7 +30,7 @@ golazo capabilities | jq '.data[0].commands'
 # 1. Discover which competitions are active
 golazo leagues
 
-# 2. Get today's full slate across active leagues
+# 2. Get today's full slate across active leagues — this is usually enough
 golazo finished --include-upcoming | jq '.data[] | {
   league: .league.name,
   status,
@@ -39,16 +39,13 @@ golazo finished --include-upcoming | jq '.data[] | {
   score: (if .home_score != null then "\(.home_score)-\(.away_score)" else null end),
   kickoff_utc: .match_time
 }'
-
-# 3. Drill into a specific match by piping its ID
-golazo finished --include-upcoming | jq -r '.data[0].id' | xargs golazo match
 ```
 
-This pattern keeps the in-process page-slug cache populated, which is what makes `match <id>` reliable. See [Known limitations](#known-limitations) for why.
+For events / lineups / stats: use `golazo match <id> --mock` against the bundled mock IDs (2001, 2002, ...) to validate your jq pipeline, then accept that against real IDs the call is best-effort.
 
 ## Subcommands
 
-> **⚠ Important for agents using `match <id>`:** cold-calling this command with an arbitrary ID is unreliable and will most likely return `upstream_error`. FotMob's details endpoint requires a page slug only populated by a prior `live` or `finished` call in the same process. **Always chain**: `golazo finished | jq -r '.data[0].id' | xargs golazo match`. See [Known limitations](#known-limitations) for the full explanation.
+> **⚠ Important for agents using `match <id>`:** this subcommand is **best-effort only**. Cold calls with arbitrary IDs typically return `upstream_error` (HTTP 404) due to a FotMob slug-cache constraint that cannot be satisfied by a one-shot CLI invocation. Reliable only with `--mock` (bundled mock IDs) or from inside the interactive TUI. For agentic use, treat the list endpoints (`live`, `finished`) as the authoritative source — they already include teams, score, status, league and kickoff time. See [Known limitations](#known-limitations) for the full explanation.
 
 | Command | Description |
 |---|---|
@@ -250,8 +247,8 @@ golazo finished --days 3 --pretty
 # Today's full slate (finished + still-to-come)
 golazo finished --include-upcoming
 
-# Single match details (use an ID from a prior list call)
-golazo finished | jq -r '.data[0].id' | xargs golazo match
+# Single match details (best-effort; reliable only against mock IDs)
+golazo match 2001 --mock
 
 # Discover league IDs to interpret results
 golazo leagues --all
@@ -282,8 +279,8 @@ golazo finished --days 3 | jq -r '.data[].id'
 # Check whether the result was degraded (partial-failure-aware retry decision)
 golazo finished --days 7 | jq '{ok: ((.degraded // false) | not), failed: (.failed_dates // [])}'
 
-# Goal events only, ordered by minute
-golazo finished | jq -r '.data[0].id' | xargs golazo match \
+# Goal events only, ordered by minute (best-effort; mock ID example)
+golazo match 2001 --mock \
   | jq '.data[0].events | map(select(.type == "goal")) | sort_by(.minute)'
 ```
 
@@ -302,7 +299,7 @@ Use this table to decide whether to retry, fix the call, or give up.
 | `invalid_args` | `2` | Bad flag value (e.g. `--days 99`, non-numeric match ID) | **No** — fix the call. Retrying will keep failing. |
 | `not_found` | `3` | Unknown match ID (mock mode), or match has no data | **No** — pick a fresh ID via a list call. |
 | `timeout` | `4` | Upstream slow or network congested | **Yes**, with a larger `--timeout` (e.g. `--timeout 30s`). |
-| `upstream_error` | `1` | FotMob 4xx/5xx, network failure, Cloudflare challenge | **Once** — transient errors recover. If the same ID keeps failing on `match`, see the slug-cache note in [Known limitations](#known-limitations). |
+| `upstream_error` | `1` | FotMob 4xx/5xx, network failure, Cloudflare challenge | **Once** — transient errors recover. For `match <id>`, do not retry on 404: cold calls are expected to fail (see [Known limitations](#known-limitations)). |
 | `offline` | `5` | `GOLAZO_OFFLINE=1` is set | **No** — unset the env var, or pass `--mock` for synthetic data. |
 
 The exit code is the most reliable retry signal. The `code` field in the error envelope on stderr says the same thing in machine-readable form; agents should prefer the exit code (no JSON parsing required).
@@ -326,18 +323,18 @@ Golazo internally rate-limits FotMob requests to one every 200ms and caps concur
 
 
 
-### `match <id>` requires IDs from a prior list call
+### `match <id>` is best-effort only
 
-FotMob's match-details endpoint is gated behind Cloudflare Turnstile when called directly. Golazo's primary fetch path retrieves details by parsing the match's page HTML using a slug that is only populated when the match appears in a list response (`live` or `finished`). Calling `golazo match <id>` against an ID that has not previously been seen in the current process will most likely return an `upstream_error` (HTTP 404 from the API fallback).
+FotMob's match-details endpoint is gated behind Cloudflare Turnstile when called directly. Golazo's primary fetch path retrieves details by parsing the match's page HTML using a slug that is only populated **inside a long-running process** (the interactive TUI). A one-shot CLI invocation never has the slug cache populated, so `golazo match <id>` against a real ID typically returns `upstream_error` (HTTP 404 from the API fallback).
 
-**Recommended agent flow**: list first, then drill in within the same shell pipeline or session:
+**What this means for agents**:
 
-```bash
-# Pick an ID from the list, then fetch its details
-golazo finished --days 1 | jq -r '.data[0].id' | xargs golazo match
-```
+- `golazo match <id>` is **not** a dependable building block for production agent pipelines.
+- Treat `live` and `finished` as the authoritative agent-facing endpoints. Both already include teams, scores, status, league, kickoff time, round, and `page_url` — enough to answer most match-level questions without needing `match`.
+- For **testing** your jq pipeline against match details, use `--mock` with the bundled mock IDs (e.g. `golazo match 2001 --mock`). The mock data exposes the full `MatchDetails` shape (events, lineups, stats, formations).
+- For **human / interactive** access to a specific match, use the TUI (`golazo`, no subcommand) and select the match.
 
-The slug cache lives in process memory and does not persist across invocations, so a fresh `golazo match <id>` cold call is not reliable. Agents should treat `match` as a follow-up step to `live` / `finished`, not a standalone lookup.
+We chose not to work around this limitation in the CLI: persisting the slug cache to disk would add complexity and a new failure mode, and FotMob's gating may change at any time. The `page_url` field on every `Match` is the slug FotMob uses; documented here in case future versions of the CLI accept it as an explicit input.
 
 ### Debug logging is sparse on list endpoints
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -76,7 +76,12 @@ For events / lineups / stats: use `golazo match <id> --mock` against the bundled
 }
 ```
 
-Single-item responses (e.g. `match <id>`) still use a `data` array with `count: 1`.
+Single-item responses (e.g. `match <id>`, `capabilities`) still use a `data` array with `count: 1`. **This is intentional** — every subcommand returns the same envelope shape so agents can write a single parser. Access singleton results with `.data[0]`:
+
+```bash
+golazo capabilities | jq '.data[0].tool'            # → "golazo"
+golazo match 2001 --mock | jq '.data[0].home_team'  # → match details
+```
 
 ### Degraded envelope
 
@@ -131,7 +136,10 @@ away_score:  int|null   # null when status == "not_started"
 match_time:  string     # RFC3339 timestamp in UTC, e.g. "2026-06-12T19:00:00Z"
 live_time:   string|null # null unless status == "live"; e.g. "45+2", "HT", "67'"
 round:       string     # e.g. "Matchday 17", "Round of 16"
-page_url:    string     # FotMob page slug (internal use; agents can ignore)
+page_url:    string     # FotMob page slug, e.g. "/matches/team-a-vs-team-b/abc123".
+                        # This is the slug the CLI would need to fetch full
+                        # match details reliably. Exposed for transparency;
+                        # not consumed by any current subcommand.
 ```
 
 ### `MatchDetails` (returned by `match`)

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -205,6 +205,37 @@ country_code: string   # often empty for international competitions
 | `GOLAZO_AGENT=1` | Forces compact JSON, enables stderr debug logging |
 | `GOLAZO_OFFLINE=1` | Refuses any network call; subcommands return `offline` unless `--mock` is set |
 
+### Recommended agent invocation
+
+For any non-human caller, always set `GOLAZO_AGENT=1`:
+
+```bash
+GOLAZO_AGENT=1 golazo <subcommand> [flags]
+```
+
+This single env var:
+
+- Forces compact (single-line) JSON regardless of `--pretty` — lower token cost
+- Routes all debug logging to stderr so stdout stays clean for `jq` pipelines
+- Acts as a future-proof "I am not a human" signal — if Golazo ever grows interactive prompts or color escapes, this flag will suppress them
+
+A repository-root `tool.json` manifest also describes the CLI for agent indexers; see the top of [the repo](https://github.com/0xjuanma/golazo/blob/main/tool.json).
+
+## Determinism guarantees
+
+Agents that diff outputs across calls (e.g. "did the score change since five minutes ago?") need to know what's stable and what's not. Within a single match:
+
+| Stable across calls | Changes during/after a match |
+|---|---|
+| `id`, `league`, `home_team`, `away_team` | `status` |
+| `match_time` (kickoff time), `venue`, `referee` | `home_score`, `away_score` |
+| `home_formation`, `away_formation` (once published) | `live_time` |
+| Starting lineup IDs (once published) | `events[]` (appends as goals/cards happen) |
+|  | `statistics[]` |
+|  | `home_xg`, `away_xg` |
+
+List endpoints (`live`, `finished`, `leagues`) sort by `match_time` then `id` for deterministic ordering — repeated invocations produce diffable output. `leagues --all` sorts by ID.
+
 ## Examples
 
 ### Basic invocations

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -106,6 +106,8 @@ Errors go to **stderr**, stdout stays empty:
 
 Error codes: `invalid_args`, `not_found`, `upstream_error`, `timeout`, `offline`.
 
+CLI-level failures (typo'd subcommand, unknown flag, bad flag value) also flow through this envelope as `invalid_args` (exit code 2). Agents can always parse stderr as JSON when the exit code is non-zero.
+
 ## Data schema
 
 Every command's `data` array contains one of three object shapes. All field names are stable across calls. Fields marked `null when ...` are present but null in those states — agents should always nil-check.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -9,7 +9,7 @@ The default `golazo` invocation still opens the TUI — the subcommands below ar
 | Command | Description |
 |---|---|
 | `golazo live` | Live matches across active leagues |
-| `golazo finished [--days N]` | Finished matches over the last N days (1..7, default 1) |
+| `golazo finished [--days N] [--include-upcoming]` | Finished matches over the last N days (1..7, default 1); use `--include-upcoming` to also include today's not-yet-started matches |
 | `golazo match <id>` | Full match details (events, lineups, stats) |
 | `golazo leagues [--all]` | Active leagues (or every supported league) |
 
@@ -90,6 +90,9 @@ golazo live
 
 # Finished matches over the last 3 days, indented
 golazo finished --days 3 --pretty
+
+# Today's full slate (finished + still-to-come)
+golazo finished --include-upcoming
 
 # Single match details
 golazo match 4506424

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -109,3 +109,22 @@ GOLAZO_AGENT=1 GOLAZO_OFFLINE=1 golazo live --mock
 - Stdout receives **only** the JSON envelope. All logs go to stderr — safe to pipe through `jq`.
 - List output is sorted deterministically (`match_time` then `id`) so repeated invocations diff cleanly.
 - The TUI experience is unchanged — no flags here alter the interactive default.
+
+## Known limitations
+
+### `match <id>` requires IDs from a prior list call
+
+FotMob's match-details endpoint is gated behind Cloudflare Turnstile when called directly. Golazo's primary fetch path retrieves details by parsing the match's page HTML using a slug that is only populated when the match appears in a list response (`live` or `finished`). Calling `golazo match <id>` against an ID that has not previously been seen in the current process will most likely return an `upstream_error` (HTTP 404 from the API fallback).
+
+**Recommended agent flow**: list first, then drill in within the same shell pipeline or session:
+
+```bash
+# Pick an ID from the list, then fetch its details
+golazo finished --days 1 | jq -r '.data[0].id' | xargs golazo match
+```
+
+The slug cache lives in process memory and does not persist across invocations, so a fresh `golazo match <id>` cold call is not reliable. Agents should treat `match` as a follow-up step to `live` / `finished`, not a standalone lookup.
+
+### Debug logging is sparse on list endpoints
+
+`--debug` and `GOLAZO_AGENT=1` only emit logs at the FotMob client's match-details fetch path. The list endpoints (`live`, `finished`, `leagues`) are largely silent. This is by design — agents are expected to interpret the JSON envelope (including `degraded` / `failed_dates`), not stderr logs.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,8 +1,47 @@
 # CLI / Agent Mode
 
-Golazo ships with a small set of subcommands that emit JSON to stdout. They are intended for agents (Claude Code, scripts, CI) that need structured match data without driving the TUI.
+Golazo ships with a small set of subcommands that emit JSON to stdout. They are intended for agents (Claude Code, Codex, scripts, CI) that need structured match data without driving the TUI.
 
 The default `golazo` invocation still opens the TUI — the subcommands below are additive.
+
+## When to use Golazo
+
+Use this tool when the user asks about football (soccer) matches. Map their question to the right command:
+
+| User asks about... | Command |
+|---|---|
+| Matches happening right now | `golazo live` |
+| Today's results (already finished) | `golazo finished --days 1` |
+| Today's full slate (finished + still-to-come) | `golazo finished --include-upcoming` |
+| Results over the last N days (≤7) | `golazo finished --days N` |
+| Details for a specific match (events, lineups, stats) | `golazo match <id>` — see [Known limitations](#known-limitations) |
+| Which competitions are tracked / what league IDs exist | `golazo leagues` (or `--all`) |
+
+If the user's question doesn't map to one of the above, this tool likely cannot answer it. Golazo does not expose: standings/tables, head-to-head history, individual player stats, transfer news, or fixtures beyond today.
+
+## Quick start (worked example)
+
+The canonical agent flow is **discover → list → drill in**. Every reliable use of `match <id>` first pulls the ID from a list call in the same pipeline:
+
+```bash
+# 1. Discover which competitions are active
+golazo leagues
+
+# 2. Get today's full slate across active leagues
+golazo finished --include-upcoming | jq '.data[] | {
+  league: .league.name,
+  status,
+  home: .home_team.name,
+  away: .away_team.name,
+  score: (if .home_score != null then "\(.home_score)-\(.away_score)" else null end),
+  kickoff_utc: .match_time
+}'
+
+# 3. Drill into a specific match by piping its ID
+golazo finished --include-upcoming | jq -r '.data[0].id' | xargs golazo match
+```
+
+This pattern keeps the in-process page-slug cache populated, which is what makes `match <id>` reliable. See [Known limitations](#known-limitations) for why.
 
 ## Subcommands
 
@@ -64,6 +103,84 @@ Errors go to **stderr**, stdout stays empty:
 
 Error codes: `invalid_args`, `not_found`, `upstream_error`, `timeout`, `offline`.
 
+## Data schema
+
+Every command's `data` array contains one of three object shapes. All field names are stable across calls. Fields marked `null when ...` are present but null in those states — agents should always nil-check.
+
+### `Match` (returned by `live`, `finished`)
+
+```yaml
+id:          int        # FotMob match ID — pass to `golazo match`
+league:
+  id:        int
+  name:      string     # e.g. "Premier League"
+  country:   string     # e.g. "England", "International", "Europe"
+home_team:
+  id:        int
+  name:      string     # full name, e.g. "Manchester United"
+  short_name: string    # abbreviated, e.g. "Man Utd"
+away_team:   { same shape as home_team }
+status:      string     # one of: "live" | "finished" | "not_started" | "postponed" | "cancelled"
+home_score:  int|null   # null when status == "not_started"
+away_score:  int|null   # null when status == "not_started"
+match_time:  string     # RFC3339 timestamp in UTC, e.g. "2026-06-12T19:00:00Z"
+live_time:   string|null # null unless status == "live"; e.g. "45+2", "HT", "67'"
+round:       string     # e.g. "Matchday 17", "Round of 16"
+page_url:    string     # FotMob page slug (internal use; agents can ignore)
+```
+
+### `MatchDetails` (returned by `match`)
+
+`MatchDetails` embeds every `Match` field above and adds:
+
+```yaml
+events:
+  - id:             int
+    minute:         int          # base minute, e.g. 45
+    display_minute: string       # formatted, e.g. "45+2'"
+    type:           string       # "goal" | "card" | "substitution"
+    team:           Team
+    player:         string|null
+    assist:         string|null
+    event_type:     string|null  # "yellow" | "red" | "in" | "out"
+    own_goal:       bool|null
+    timestamp:      string       # RFC3339
+home_lineup:        []string     # player names (legacy; prefer home_starting)
+away_lineup:        []string
+home_starting:                   # full lineup detail
+  - { id, name, number, position, rating }
+away_starting:      [...]
+home_substitutes:   [...]
+away_substitutes:   [...]
+home_formation:     string       # e.g. "4-3-3"
+away_formation:     string
+home_score / away_score:         # final score (always set for finished)
+half_time_score:    { home, away } | absent
+penalties:          { home, away } | absent
+venue:              string
+referee:            string
+attendance:         int
+match_duration:     int          # 90, 120
+extra_time:         bool
+statistics:                       # possession, shots, etc.
+  - { key, label, home_value, away_value }
+home_xg / away_xg:  number|absent
+highlight:                        # YouTube/source link if available
+  { url, image, source, title } | absent
+aggregate_score:    string       # two-legged ties only, e.g. "5 - 7"
+who_lost_on_aggregate: string    # team name eliminated
+winner:             "home"|"away"|null
+```
+
+### `League` (returned by `leagues`)
+
+```yaml
+id:           int
+name:         string
+country:      string
+country_code: string   # often empty for international competitions
+```
+
 ## Exit codes
 
 | Code | Meaning |
@@ -84,6 +201,8 @@ Error codes: `invalid_args`, `not_found`, `upstream_error`, `timeout`, `offline`
 
 ## Examples
 
+### Basic invocations
+
 ```bash
 # Live matches, compact JSON
 golazo live
@@ -94,17 +213,41 @@ golazo finished --days 3 --pretty
 # Today's full slate (finished + still-to-come)
 golazo finished --include-upcoming
 
-# Single match details
-golazo match 4506424
+# Single match details (use an ID from a prior list call)
+golazo finished | jq -r '.data[0].id' | xargs golazo match
 
 # Discover league IDs to interpret results
 golazo leagues --all
 
-# Pipe through jq
-golazo live | jq '.data[] | {home: .home_team.name, away: .away_team.name, score: "\(.home_score)-\(.away_score)"}'
-
 # Agent mode + offline safety in CI
 GOLAZO_AGENT=1 GOLAZO_OFFLINE=1 golazo live --mock
+```
+
+### jq recipes
+
+Most agent flows pipe Golazo's output through `jq`. These are the patterns worth memorizing:
+
+```bash
+# One-line live score summary
+golazo live | jq -r '.data[] | "\(.home_team.name) \(.home_score)-\(.away_score) \(.away_team.name) [\(.live_time)]"'
+
+# Filter by league name (case-insensitive match)
+golazo finished --include-upcoming \
+  | jq '[.data[] | select(.league.name | test("World Cup"; "i"))]'
+
+# Filter by status (e.g. only what's still to come)
+golazo finished --include-upcoming \
+  | jq '[.data[] | select(.status == "not_started")]'
+
+# Extract just IDs, ready for chaining to `match`
+golazo finished --days 3 | jq -r '.data[].id'
+
+# Check whether the result was degraded (partial-failure-aware retry decision)
+golazo finished --days 7 | jq '{ok: ((.degraded // false) | not), failed: (.failed_dates // [])}'
+
+# Goal events only, ordered by minute
+golazo finished | jq -r '.data[0].id' | xargs golazo match \
+  | jq '.data[0].events | map(select(.type == "goal")) | sort_by(.minute)'
 ```
 
 ## Notes

--- a/tool.json
+++ b/tool.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "1",
+  "name": "golazo",
+  "description": "JSON CLI for football match data (live, finished, details, leagues). Intended for agentic dev tools (Claude Code, Codex, MCP servers) and scripts.",
+  "homepage": "https://github.com/0xjuanma/golazo",
+  "docs": "https://github.com/0xjuanma/golazo/blob/main/docs/CLI.md",
+  "agent_mode": {
+    "binary": "golazo",
+    "discovery": "golazo capabilities",
+    "env": {
+      "GOLAZO_AGENT": "1",
+      "GOLAZO_OFFLINE": "0"
+    },
+    "output": {
+      "format": "json",
+      "channel": "stdout",
+      "errors_channel": "stderr"
+    },
+    "subcommands": ["live", "finished", "match", "leagues", "capabilities"],
+    "recommended_invocation": "GOLAZO_AGENT=1 golazo <subcommand> [flags]"
+  },
+  "tags": ["football", "soccer", "sports", "json", "cli", "agent-cli", "claude-code"]
+}


### PR DESCRIPTION
## Summary
Makes Golazo usable by agentic dev tools (Claude Code, Codex, etc) by adding a JSON CLI alongside the unchanged TUI.

## Updates
- New subcommands: `live`, `finished`, `match`, `leagues`, `capabilities` with a stable envelope, typed error codes and documented exit codes
- Guardrails: `--timeout`, `GOLAZO_AGENT` and `GOLAZO_OFFLINE` env vars, strict stdout/stderr split, deterministic ordering, degraded-result flag
- Self-describing contract via `golazo capabilities` plus full agent docs in `docs/CLI.md` and a `tool.json` manifest