### PR TITLE
fix[ui/worldcup]: align grid rows and drop stray group panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
-- **World Cup Grid Alignment** - Fixed misaligned rows and a stray extra group panel in the World Cup grid view.
+- **World Cup Grid Alignment** - Reworked the World Cup grid to render consistently across terminals and cleared stale content when navigating between sub-views.
 
 ## [0.27.0] - 2026-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **World Cup Grid Alignment** - Fixed misaligned rows and a stray extra group panel in the World Cup grid view.
 
 ## [0.27.0] - 2026-06-12
 

--- a/internal/app/wc_handlers.go
+++ b/internal/app/wc_handlers.go
@@ -38,7 +38,7 @@ func (m model) handleWCGroupsKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "esc":
 		m.wcSubView = wcSubViewGroupGrid
-		return m, nil
+		return m, tea.ClearScreen
 
 	case "enter":
 		if item, ok := m.wcGroupsList.SelectedItem().(ui.WCGroupItem); ok {
@@ -49,6 +49,7 @@ func (m model) handleWCGroupsKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				}
 			}
 			m.wcSubView = wcSubViewGroupDetail
+			return m, tea.ClearScreen
 		}
 		return m, nil
 
@@ -56,6 +57,7 @@ func (m model) handleWCGroupsKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if len(m.wcData.KnockoutRounds) > 0 {
 			m.wcBracketScroll = 0
 			m.wcSubView = wcSubViewBracket
+			return m, tea.ClearScreen
 		}
 		return m, nil
 
@@ -63,7 +65,7 @@ func (m model) handleWCGroupsKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.wcSubView = wcSubViewUpcoming
 		m.wcUpcomingLoading = true
 		m.wcUpcomingLastError = ""
-		return m, fetchWorldCupUpcoming(m.loadCtx, m.fotmobClient)
+		return m, tea.Batch(tea.ClearScreen, fetchWorldCupUpcoming(m.loadCtx, m.fotmobClient))
 
 	default:
 		var cmd tea.Cmd
@@ -77,6 +79,7 @@ func (m model) handleWCGroupDetailKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "esc":
 		m.wcSubView = wcSubViewGroupGrid
+		return m, tea.ClearScreen
 	}
 	return m, nil
 }
@@ -86,11 +89,12 @@ func (m model) handleWCBracketKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "esc":
 		m.wcSubView = wcSubViewGroupGrid
+		return m, tea.ClearScreen
 	case "u":
 		m.wcSubView = wcSubViewUpcoming
 		m.wcUpcomingLoading = true
 		m.wcUpcomingLastError = ""
-		return m, fetchWorldCupUpcoming(m.loadCtx, m.fotmobClient)
+		return m, tea.Batch(tea.ClearScreen, fetchWorldCupUpcoming(m.loadCtx, m.fotmobClient))
 	case "j", "down":
 		if m.wcBracketLines > 0 && m.wcBracketScroll < m.wcBracketLines-1 {
 			m.wcBracketScroll++
@@ -128,21 +132,24 @@ func (m model) handleWCGroupGridKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "enter":
 		m.wcSelectedGroup = m.wcGridSelectedIdx
 		m.wcSubView = wcSubViewGroupDetail
+		return m, tea.ClearScreen
 
 	case "t":
 		m.wcSubView = wcSubViewGroups
+		return m, tea.ClearScreen
 
 	case "b":
 		if len(m.wcData.KnockoutRounds) > 0 {
 			m.wcBracketScroll = 0
 			m.wcSubView = wcSubViewBracket
+			return m, tea.ClearScreen
 		}
 
 	case "u":
 		m.wcSubView = wcSubViewUpcoming
 		m.wcUpcomingLoading = true
 		m.wcUpcomingLastError = ""
-		return m, fetchWorldCupUpcoming(m.loadCtx, m.fotmobClient)
+		return m, tea.Batch(tea.ClearScreen, fetchWorldCupUpcoming(m.loadCtx, m.fotmobClient))
 
 	case "right", "l":
 		if m.wcGridSelectedIdx < n-1 {
@@ -192,6 +199,7 @@ func (m model) handleWCUpcomingKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "esc":
 		m.wcSubView = wcSubViewGroupGrid
+		return m, tea.ClearScreen
 	}
 	return m, nil
 }

--- a/internal/fotmob/worldcup.go
+++ b/internal/fotmob/worldcup.go
@@ -134,6 +134,11 @@ func fetchWorldCupPage(ctx context.Context, httpClient *http.Client, season stri
 
 // parseWCGroups extracts group standings from the page response.
 // Handles both 8-group (Qatar 2022) and 12-group (USA 2026) formats.
+//
+// FotMob occasionally ships pseudo-tables alongside the real groups (e.g.
+// "Qualified teams", "Pot teams") whose derived "letter" is a word rather
+// than a single character. Those are filtered out so the UI grid stays
+// symmetric (#158).
 func parseWCGroups(resp wcPageResponse) []api.WCGroup {
 	if len(resp.Table) == 0 {
 		return nil
@@ -148,6 +153,9 @@ func parseWCGroups(resp wcPageResponse) []api.WCGroup {
 
 		// Derive group letter from leagueName ("Grp. A" → "A")
 		letter := wcGroupLetter(t.LeagueName)
+		if !isWCGroupLetter(letter) {
+			continue
+		}
 
 		entries := make([]api.LeagueTableEntry, 0, len(t.Table.All))
 		for _, row := range t.Table.All {
@@ -162,6 +170,18 @@ func parseWCGroups(resp wcPageResponse) []api.WCGroup {
 		})
 	}
 	return groups
+}
+
+// isWCGroupLetter reports whether s is a single uppercase ASCII letter, the
+// shape every real WC group identifier takes (A–L). Anything else is a
+// FotMob pseudo-table (e.g. "teams" from "Qualified teams") and must be
+// dropped before reaching the renderer.
+func isWCGroupLetter(s string) bool {
+	if len(s) != 1 {
+		return false
+	}
+	c := s[0]
+	return c >= 'A' && c <= 'Z'
 }
 
 // parseWCBracket extracts the knockout bracket from the playoff data.

--- a/internal/fotmob/worldcup.go
+++ b/internal/fotmob/worldcup.go
@@ -159,6 +159,13 @@ func parseWCGroups(resp wcPageResponse) []api.WCGroup {
 
 		entries := make([]api.LeagueTableEntry, 0, len(t.Table.All))
 		for _, row := range t.Table.All {
+			// Skip placeholder rows (TBD slots, qualifier annotations)
+			// that FotMob occasionally interleaves with real teams. They
+			// would otherwise inflate the rendered cell height and push
+			// the grid out of alignment (#158).
+			if strings.TrimSpace(row.Name) == "" && strings.TrimSpace(row.ShortName) == "" {
+				continue
+			}
 			entries = append(entries, row.toAPITableEntry())
 		}
 

--- a/internal/fotmob/worldcup_test.go
+++ b/internal/fotmob/worldcup_test.go
@@ -64,6 +64,59 @@ func TestParseWCGroups_TwelveGroups(t *testing.T) {
 	}
 }
 
+// TestParseWCGroups_FiltersNonLetterTables locks in the fix for #158: FotMob
+// sometimes ships pseudo-tables alongside the real groups (e.g. a "Qualified
+// teams" pot table). Those must be dropped so the grid stays symmetric.
+func TestParseWCGroups_FiltersNonLetterTables(t *testing.T) {
+	resp := buildMockWCPageResponse(12)
+
+	// Inject two pseudo-tables: one whose name yields a word ("teams"), one
+	// whose name yields the empty string. Both must be filtered out.
+	pseudo := resp.Table[0].Data.Tables[0]
+	pseudo.LeagueID = 999001
+	pseudo.LeagueName = "Qualified teams"
+	resp.Table[0].Data.Tables = append(resp.Table[0].Data.Tables, pseudo)
+
+	empty := resp.Table[0].Data.Tables[0]
+	empty.LeagueID = 999002
+	empty.LeagueName = ""
+	resp.Table[0].Data.Tables = append(resp.Table[0].Data.Tables, empty)
+
+	groups := parseWCGroups(resp)
+	if len(groups) != 12 {
+		t.Fatalf("len(groups) = %d, want 12 (pseudo-tables not filtered)", len(groups))
+	}
+	for i, g := range groups {
+		if !isWCGroupLetter(g.Letter) {
+			t.Errorf("groups[%d].Letter = %q, want single uppercase letter", i, g.Letter)
+		}
+		if g.Name == "Group teams" {
+			t.Errorf("groups[%d] is the pseudo-table that should have been filtered", i)
+		}
+	}
+}
+
+func TestIsWCGroupLetter(t *testing.T) {
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		{"A", true},
+		{"L", true},
+		{"Z", true},
+		{"", false},
+		{"AA", false},
+		{"teams", false},
+		{"a", false}, // lowercase rejected; wcGroupLetter uppercases via FotMob input
+		{"1", false},
+	}
+	for _, tt := range tests {
+		if got := isWCGroupLetter(tt.in); got != tt.want {
+			t.Errorf("isWCGroupLetter(%q) = %v, want %v", tt.in, got, tt.want)
+		}
+	}
+}
+
 func TestParseWCBracket_Empty(t *testing.T) {
 	rounds, bronze := parseWCBracket(wcPlayoff{})
 	if len(rounds) != 0 {

--- a/internal/fotmob/worldcup_test.go
+++ b/internal/fotmob/worldcup_test.go
@@ -117,6 +117,36 @@ func TestIsWCGroupLetter(t *testing.T) {
 	}
 }
 
+// TestParseWCGroups_DropsEmptyTeamRows covers the row-4 gap reported on
+// macOS Terminal under #158: FotMob occasionally interleaves placeholder
+// rows (empty name + empty shortName) inside a group's standings. Those
+// would inflate the rendered cell height and push the grid layout out of
+// alignment, so the parser drops them.
+func TestParseWCGroups_DropsEmptyTeamRows(t *testing.T) {
+	resp := buildMockWCPageResponse(1)
+	// Inject an empty-name placeholder between real teams.
+	resp.Table[0].Data.Tables[0].Table.All = []fotmobTableRow{
+		{ID: 1, Name: "Team1", ShortName: "TM1", Idx: 1, Pts: 9},
+		{ID: 2, Name: "Team2", ShortName: "TM2", Idx: 2, Pts: 6},
+		{ID: 0, Name: "", ShortName: "", Idx: 3, Pts: 0}, // pseudo-row
+		{ID: 3, Name: "Team3", ShortName: "TM3", Idx: 3, Pts: 4},
+		{ID: 4, Name: "Team4", ShortName: "TM4", Idx: 4, Pts: 1},
+	}
+
+	groups := parseWCGroups(resp)
+	if len(groups) != 1 {
+		t.Fatalf("len(groups) = %d, want 1", len(groups))
+	}
+	if got := len(groups[0].Teams); got != 4 {
+		t.Errorf("len(teams) = %d, want 4 (empty pseudo-row not filtered)", got)
+	}
+	for i, te := range groups[0].Teams {
+		if te.Team.Name == "" && te.Team.ShortName == "" {
+			t.Errorf("teams[%d] retained empty placeholder row", i)
+		}
+	}
+}
+
 func TestParseWCBracket_Empty(t *testing.T) {
 	rounds, bronze := parseWCBracket(wcPlayoff{})
 	if len(rounds) != 0 {

--- a/internal/ui/worldcup/bracket.go
+++ b/internal/ui/worldcup/bracket.go
@@ -185,7 +185,11 @@ func renderBracketLine(mu api.WCMatchup) string {
 }
 
 func renderBracketLineRaw(mu api.WCMatchup, showArrow bool) string {
-	const nameW = 8 // "<emoji> CODE" → typically 6 visual cells; small slack
+	// Tie name column width to labelTargetWidth so any future change to the
+	// label budget (see team_label.go) propagates here. The extra cells of
+	// slack give the bracket some breathing room without affecting the
+	// per-row width-invariance guarantee.
+	const nameW = labelTargetWidth + 2
 	const scoreW = 7
 
 	home := MatchupTeamLabel(mu.HomeShort, mu.HomeTeam, mu.TBDHome)

--- a/internal/ui/worldcup/bracket.go
+++ b/internal/ui/worldcup/bracket.go
@@ -120,7 +120,7 @@ func RenderBracket(width, height int, wcData *api.WorldCupData, scrollOffset int
 	}
 	parts = append(parts, header, "", PanelStyle.Width(width-2).Render(visible), scrollIndicator, help)
 
-	return lipgloss.JoinVertical(lipgloss.Left, parts...)
+	return padToHeight(lipgloss.JoinVertical(lipgloss.Left, parts...), height)
 }
 
 // renderBracketRound renders all matchups in a round, pairing consecutive

--- a/internal/ui/worldcup/bracket_test.go
+++ b/internal/ui/worldcup/bracket_test.go
@@ -78,3 +78,52 @@ func TestRenderBracketRound_ConnectorAlignment(t *testing.T) {
 }
 
 func intPtrLocal(i int) *int { return &i }
+
+// TestRenderBracketLineRaw_WidthInvariant locks in the fix for #158: bracket
+// match lines must render at the same total visual width regardless of which
+// flag form (regional-indicator pair, tag-sequence subdivision, or no-flag
+// placeholder) appears in either team slot.
+func TestRenderBracketLineRaw_WidthInvariant(t *testing.T) {
+	winner := 1
+	probes := []struct {
+		name string
+		mu   api.WCMatchup
+	}{
+		{"RIS+RIS", api.WCMatchup{
+			HomeTeam: "Mexico", HomeTeamID: 1, HomeShort: "MEX",
+			AwayTeam: "Brazil", AwayTeamID: 2, AwayShort: "BRA",
+			HomeScore: intPtrLocal(1), AwayScore: intPtrLocal(0),
+			WinnerID: &winner,
+		}},
+		{"tag+RIS", api.WCMatchup{
+			HomeTeam: "England", HomeTeamID: 1, HomeShort: "ENG",
+			AwayTeam: "Mexico", AwayTeamID: 2, AwayShort: "MEX",
+			HomeScore: intPtrLocal(1), AwayScore: intPtrLocal(0),
+			WinnerID: &winner,
+		}},
+		{"RIS+placeholder", api.WCMatchup{
+			HomeTeam: "Mexico", HomeTeamID: 1, HomeShort: "MEX",
+			AwayTeam: "Nowhereland", AwayTeamID: 2, AwayShort: "ZZZ",
+			HomeScore: intPtrLocal(1), AwayScore: intPtrLocal(0),
+			WinnerID: &winner,
+		}},
+		{"placeholder+placeholder", api.WCMatchup{
+			HomeTeam: "Nowhereland", HomeTeamID: 1, HomeShort: "ZZZ",
+			AwayTeam: "Otherland", AwayTeamID: 2, AwayShort: "YYY",
+			HomeScore: intPtrLocal(1), AwayScore: intPtrLocal(0),
+			WinnerID: &winner,
+		}},
+	}
+
+	var widths []int
+	for _, p := range probes {
+		line := renderBracketLineRaw(p.mu, false)
+		widths = append(widths, lipgloss.Width(line))
+	}
+	for i := 1; i < len(widths); i++ {
+		if widths[i] != widths[0] {
+			t.Errorf("bracket line width differs across flag forms: probe[0] %s = %d, probe[%d] %s = %d",
+				probes[0].name, widths[0], i, probes[i].name, widths[i])
+		}
+	}
+}

--- a/internal/ui/worldcup/groups.go
+++ b/internal/ui/worldcup/groups.go
@@ -280,6 +280,13 @@ func RenderGroupGrid(width, height int, wcData *api.WorldCupData, selectedGroupI
 	if cellW < 20 {
 		cellW = 20
 	}
+	// Cell content height = 1 title + gridCellTeamRows team rows. Pinning
+	// Height on the bordered style guarantees every cell in the grid
+	// renders at the same total height — including the empty filler cells
+	// used when groups count isn't a multiple of cols — so JoinHorizontal
+	// never has to pad and row-to-row spacing stays uniform across
+	// terminals with different emoji-width interpretations.
+	const cellContentH = 1 + gridCellTeamRows
 
 	var rows []string
 	for rowStart := 0; rowStart < len(wcData.Groups); rowStart += cols {
@@ -287,7 +294,10 @@ func RenderGroupGrid(width, height int, wcData *api.WorldCupData, selectedGroupI
 		for c := 0; c < cols; c++ {
 			gIdx := rowStart + c
 			if gIdx >= len(wcData.Groups) {
-				cells = append(cells, lipgloss.NewStyle().Width(cellW+2).Render(""))
+				cells = append(cells, lipgloss.NewStyle().
+					Width(cellW+2).
+					Height(cellContentH+2).
+					Render(""))
 				continue
 			}
 			g := wcData.Groups[gIdx]
@@ -297,9 +307,9 @@ func RenderGroupGrid(width, height int, wcData *api.WorldCupData, selectedGroupI
 
 			var cellStyle lipgloss.Style
 			if selected {
-				cellStyle = GridSelectedGroupStyle.Width(cellW)
+				cellStyle = GridSelectedGroupStyle.Width(cellW).Height(cellContentH)
 			} else {
-				cellStyle = GridNormalGroupStyle.Width(cellW)
+				cellStyle = GridNormalGroupStyle.Width(cellW).Height(cellContentH)
 			}
 			cells = append(cells, cellStyle.Render(content))
 		}
@@ -324,13 +334,22 @@ func RenderGroupGrid(width, height int, wcData *api.WorldCupData, selectedGroupI
 // visual width of regional-indicator / tag-sequence flag clusters. Without
 // this pin, terminals following the legacy width table (or rendering tag
 // sequences without clustering) push neighboring rows out of column.
+//
+// The cell is also padded/truncated to a fixed line count so every cell in
+// the grid occupies the same vertical space regardless of how many rows
+// FotMob ships per group (4 in normal play, occasionally more in qualifier
+// formats or alongside playoff annotations).
 func renderGroupGridCell(g api.WCGroup, width int) string {
 	title := GridGroupHeaderStyle.Render(g.Name)
 	lines := []string{title}
 	// labelTargetWidth is the visual budget every TeamLabel is padded to;
 	// add 1 cell of trailing breathing room before the points column.
 	const labelCellW = labelTargetWidth + 1
+	teamLines := make([]string, 0, gridCellTeamRows)
 	for i, t := range g.Teams {
+		if i >= gridCellTeamRows {
+			break
+		}
 		pts := fmt.Sprintf("%2d", t.Points)
 
 		var ts lipgloss.Style
@@ -348,7 +367,20 @@ func renderGroupGridCell(g api.WCGroup, width int) string {
 		// on flag-emoji visual widths.
 		label := ts.Width(labelCellW).Render(TeamLabel(t.Team))
 		line := "  " + label + ts.Render(pts)
-		lines = append(lines, line)
+		teamLines = append(teamLines, line)
 	}
+	// Pad to a fixed row count so the bordered cell height is identical
+	// across every group, even when FotMob ships fewer than the expected
+	// number of teams (e.g. early qualifier rounds).
+	for len(teamLines) < gridCellTeamRows {
+		teamLines = append(teamLines, "")
+	}
+	lines = append(lines, teamLines...)
 	return strings.Join(lines, "\n")
 }
+
+// gridCellTeamRows is the fixed number of team rows rendered per grid cell.
+// Normal WC groups carry exactly 4 teams; the constant exists so the cell
+// height is deterministic regardless of any extra rows FotMob may ship
+// (qualifier playoffs, "to be determined" placeholders, etc.).
+const gridCellTeamRows = 4

--- a/internal/ui/worldcup/groups.go
+++ b/internal/ui/worldcup/groups.go
@@ -276,16 +276,13 @@ func RenderGroupGrid(width, height int, wcData *api.WorldCupData, selectedGroupI
 		cols = 3
 	}
 
-	cellW := (width - cols - 2) / cols
+	cellW := width / cols
 	if cellW < 20 {
 		cellW = 20
 	}
-	// Cell content height = 1 title + gridCellTeamRows team rows. Pinning
-	// Height on the bordered style guarantees every cell in the grid
-	// renders at the same total height — including the empty filler cells
-	// used when groups count isn't a multiple of cols — so JoinHorizontal
-	// never has to pad and row-to-row spacing stays uniform across
-	// terminals with different emoji-width interpretations.
+	// Cell content height = 1 title + gridCellTeamRows team rows. Padding
+	// every cell to this fixed height keeps row-to-row spacing uniform
+	// when groups carry differing team counts.
 	const cellContentH = 1 + gridCellTeamRows
 
 	var rows []string
@@ -295,23 +292,26 @@ func RenderGroupGrid(width, height int, wcData *api.WorldCupData, selectedGroupI
 			gIdx := rowStart + c
 			if gIdx >= len(wcData.Groups) {
 				cells = append(cells, lipgloss.NewStyle().
-					Width(cellW+2).
-					Height(cellContentH+2).
+					Width(cellW).
+					Height(cellContentH).
 					Render(""))
 				continue
 			}
 			g := wcData.Groups[gIdx]
 			selected := gIdx == selectedGroupIdx
 
-			content := renderGroupGridCell(g, cellW-4)
+			content := renderGroupGridCell(g, cellW-2, selected)
 
-			var cellStyle lipgloss.Style
+			cellStyle := GridNormalGroupStyle.Width(cellW).Height(cellContentH)
 			if selected {
 				cellStyle = GridSelectedGroupStyle.Width(cellW).Height(cellContentH)
-			} else {
-				cellStyle = GridNormalGroupStyle.Width(cellW).Height(cellContentH)
 			}
 			cells = append(cells, cellStyle.Render(content))
+		}
+		// Add a blank visual gutter line between rows so cells in different
+		// horizontal rows don't visually merge without borders.
+		if len(rows) > 0 {
+			rows = append(rows, "")
 		}
 		rows = append(rows, lipgloss.JoinHorizontal(lipgloss.Top, cells...))
 	}
@@ -358,8 +358,16 @@ func padToHeight(s string, height int) string {
 // the grid occupies the same vertical space regardless of how many rows
 // FotMob ships per group (4 in normal play, occasionally more in qualifier
 // formats or alongside playoff annotations).
-func renderGroupGridCell(g api.WCGroup, width int) string {
-	title := GridGroupHeaderStyle.Render(g.Name)
+//
+// Selection is conveyed by switching the title color instead of drawing a
+// border, because box-drawing characters disagree with neighboring cells'
+// flag-emoji widths across terminals (#158).
+func renderGroupGridCell(g api.WCGroup, width int, selected bool) string {
+	titleStyle := GridGroupHeaderStyle
+	if selected {
+		titleStyle = GridSelectedGroupHeaderStyle
+	}
+	title := titleStyle.Render(g.Name)
 	lines := []string{title}
 	// labelTargetWidth is the visual budget every TeamLabel is padded to;
 	// add 1 cell of trailing breathing room before the points column.

--- a/internal/ui/worldcup/groups.go
+++ b/internal/ui/worldcup/groups.go
@@ -318,9 +318,18 @@ func RenderGroupGrid(width, height int, wcData *api.WorldCupData, selectedGroupI
 }
 
 // renderGroupGridCell renders a mini standings table for a single group cell.
+//
+// The team-label column is rendered with an explicit lipgloss width so that
+// row alignment doesn't depend on the terminal agreeing with lipgloss on the
+// visual width of regional-indicator / tag-sequence flag clusters. Without
+// this pin, terminals following the legacy width table (or rendering tag
+// sequences without clustering) push neighboring rows out of column.
 func renderGroupGridCell(g api.WCGroup, width int) string {
 	title := GridGroupHeaderStyle.Render(g.Name)
 	lines := []string{title}
+	// labelTargetWidth is the visual budget every TeamLabel is padded to;
+	// add 1 cell of trailing breathing room before the points column.
+	const labelCellW = labelTargetWidth + 1
 	for i, t := range g.Teams {
 		pts := fmt.Sprintf("%2d", t.Points)
 
@@ -334,11 +343,11 @@ func renderGroupGridCell(g api.WCGroup, width int) string {
 			ts = GridTeamDimStyle
 		}
 
-		// Render emoji+code as a single styled chunk to avoid terminals
-		// dropping the regional-indicator pair when sandwiched between
-		// neighboring ANSI escape sequences.
-		label := ts.Render(TeamLabel(t.Team))
-		line := "  " + label + " " + ts.Render(pts)
+		// Render emoji+code as a single styled chunk pinned to a fixed
+		// width so rows align even when terminals disagree with lipgloss
+		// on flag-emoji visual widths.
+		label := ts.Width(labelCellW).Render(TeamLabel(t.Team))
+		line := "  " + label + ts.Render(pts)
 		lines = append(lines, line)
 	}
 	return strings.Join(lines, "\n")

--- a/internal/ui/worldcup/groups.go
+++ b/internal/ui/worldcup/groups.go
@@ -119,7 +119,7 @@ func RenderGroupsList(width, height int, wcData *api.WorldCupData, groupsList li
 	}
 	parts = append(parts, "", groupsList.View(), help)
 
-	return lipgloss.JoinVertical(lipgloss.Left, parts...)
+	return padToHeight(lipgloss.JoinVertical(lipgloss.Left, parts...), height)
 }
 
 // ── Group detail view ─────────────────────────────────────────────────────────
@@ -154,7 +154,7 @@ func RenderGroupDetail(width, height int, wcData *api.WorldCupData, groupIdx int
 	}
 	parts = append(parts, header, "", table, "", qual, "", help)
 
-	return lipgloss.JoinVertical(lipgloss.Left, parts...)
+	return padToHeight(lipgloss.JoinVertical(lipgloss.Left, parts...), height)
 }
 
 // renderGroupStandingsTable renders the full standings table for a group.
@@ -324,7 +324,26 @@ func RenderGroupGrid(width, height int, wcData *api.WorldCupData, selectedGroupI
 	}
 	parts = append(parts, header, "", gridContent, "", help)
 
-	return lipgloss.JoinVertical(lipgloss.Left, parts...)
+	return padToHeight(lipgloss.JoinVertical(lipgloss.Left, parts...), height)
+}
+
+// padToHeight pads s with trailing blank lines (or truncates) so its line
+// count is exactly height. Returning a fixed-height frame to bubbletea
+// prevents trailing content from a previous, taller view from leaking into
+// the bottom of the next frame on terminals whose diffing model doesn't
+// auto-erase shrunk lines.
+func padToHeight(s string, height int) string {
+	if height <= 0 {
+		return s
+	}
+	lines := strings.Split(s, "\n")
+	if len(lines) >= height {
+		return strings.Join(lines[:height], "\n")
+	}
+	for len(lines) < height {
+		lines = append(lines, "")
+	}
+	return strings.Join(lines, "\n")
 }
 
 // renderGroupGridCell renders a mini standings table for a single group cell.

--- a/internal/ui/worldcup/groups_test.go
+++ b/internal/ui/worldcup/groups_test.go
@@ -21,7 +21,7 @@ func sampleGroup() api.WCGroup {
 }
 
 func TestRenderGroupGridCell_EmojiAdjacentToName(t *testing.T) {
-	cell := renderGroupGridCell(sampleGroup(), 30)
+	cell := renderGroupGridCell(sampleGroup(), 30, false)
 
 	argFlag := FlagEmoji("ARG")
 	fraFlag := FlagEmoji("FRA")
@@ -92,7 +92,7 @@ func TestRenderGroupGridCell_WidthInvariant(t *testing.T) {
 		},
 	}
 
-	cell := renderGroupGridCell(mixed, 30)
+	cell := renderGroupGridCell(mixed, 30, false)
 	rows := strings.Split(cell, "\n")
 	if len(rows) < 5 {
 		t.Fatalf("expected header + 4 team rows, got %d lines:\n%s", len(rows), cell)
@@ -198,7 +198,7 @@ func TestRenderGroupGridCell_FixedHeight(t *testing.T) {
 		g    api.WCGroup
 	}{{"short", short}, {"long", long}} {
 		t.Run(tc.name, func(t *testing.T) {
-			cell := renderGroupGridCell(tc.g, 30)
+			cell := renderGroupGridCell(tc.g, 30, false)
 			got := strings.Count(cell, "\n") + 1
 			if got != wantLines {
 				t.Errorf("renderGroupGridCell(%s) produced %d lines, want %d\ncell:\n%s",
@@ -239,28 +239,39 @@ func TestRenderGroupGrid_RowHeightInvariant(t *testing.T) {
 	}
 	wc := &api.WorldCupData{Name: "Test WC", Groups: groups}
 
-	out := RenderGroupGrid(120, 60, wc, 0, "")
-	lines := strings.Split(out, "\n")
+	out := RenderGroupGrid(120, 200, wc, 0, "")
 
-	var rowHeights []int
-	start := -1
-	for i, line := range lines {
-		if strings.Contains(line, "┌") && start < 0 {
-			start = i
-		}
-		if strings.Contains(line, "└") && start >= 0 {
-			rowHeights = append(rowHeights, i-start+1)
-			start = -1
-		}
-	}
-	if len(rowHeights) < 4 {
-		t.Fatalf("expected at least 4 grid rows, got %d (heights: %v)\noutput:\n%s",
-			len(rowHeights), rowHeights, out)
-	}
-	for i := 1; i < len(rowHeights); i++ {
-		if rowHeights[i] != rowHeights[0] {
-			t.Errorf("grid row %d height = %d, row 0 height = %d (all heights: %v)",
-				i, rowHeights[i], rowHeights[0], rowHeights)
+	// Find the rendered group titles for the first cell of each visual
+	// row (A, D, G, J). With the borderless layout each cell starts on
+	// its own line; verify those start lines are evenly spaced so the row
+	// height is uniform regardless of differing per-group team counts.
+	lines := strings.Split(out, "\n")
+	var titleLineIdx []int
+	for _, key := range []string{"Group A", "Group D", "Group G", "Group J"} {
+		for i, line := range lines {
+			if strings.Contains(line, key) {
+				titleLineIdx = append(titleLineIdx, i)
+				break
+			}
 		}
 	}
+	if len(titleLineIdx) != 4 {
+		t.Fatalf("expected 4 row-start title lines, found %d at %v\noutput:\n%s",
+			len(titleLineIdx), titleLineIdx, out)
+	}
+	gap := titleLineIdx[1] - titleLineIdx[0]
+	for i := 2; i < len(titleLineIdx); i++ {
+		if titleLineIdx[i]-titleLineIdx[i-1] != gap {
+			t.Errorf("grid row spacing not uniform: gaps = %v (titles at %v)",
+				diffs(titleLineIdx), titleLineIdx)
+		}
+	}
+}
+
+func diffs(in []int) []int {
+	out := make([]int, 0, len(in)-1)
+	for i := 1; i < len(in); i++ {
+		out = append(out, in[i]-in[i-1])
+	}
+	return out
 }

--- a/internal/ui/worldcup/groups_test.go
+++ b/internal/ui/worldcup/groups_test.go
@@ -107,3 +107,101 @@ func TestRenderGroupGridCell_WidthInvariant(t *testing.T) {
 		}
 	}
 }
+
+// TestRenderGroupGridCell_FixedHeight locks in the fix for the row-4 gap
+// reported on macOS Terminal under #158: every cell must render at exactly
+// 1 + gridCellTeamRows lines regardless of how many teams FotMob ships.
+// Without this, JoinHorizontal pads shorter cells with whitespace that
+// surfaces as vertical drift in the bordered grid layout.
+func TestRenderGroupGridCell_FixedHeight(t *testing.T) {
+	short := api.WCGroup{
+		ID: 1, Letter: "S", Name: "Group S",
+		Teams: []api.LeagueTableEntry{
+			{Position: 1, Team: api.Team{Name: "Mexico", ShortName: "MEX"}, Points: 3},
+			{Position: 2, Team: api.Team{Name: "Brazil", ShortName: "BRA"}, Points: 1},
+		},
+	}
+	long := api.WCGroup{
+		ID: 2, Letter: "L", Name: "Group L",
+		Teams: []api.LeagueTableEntry{
+			{Position: 1, Team: api.Team{Name: "Mexico", ShortName: "MEX"}, Points: 9},
+			{Position: 2, Team: api.Team{Name: "England", ShortName: "ENG"}, Points: 6},
+			{Position: 3, Team: api.Team{Name: "South Korea", ShortName: "SOU"}, Points: 4},
+			{Position: 4, Team: api.Team{Name: "Nowhereland", ShortName: "ZZZ"}, Points: 1},
+			{Position: 5, Team: api.Team{Name: "Extra", ShortName: "EXT"}, Points: 0},
+			{Position: 6, Team: api.Team{Name: "More", ShortName: "MOR"}, Points: 0},
+		},
+	}
+
+	const wantLines = 1 + gridCellTeamRows
+	for _, tc := range []struct {
+		name string
+		g    api.WCGroup
+	}{{"short", short}, {"long", long}} {
+		t.Run(tc.name, func(t *testing.T) {
+			cell := renderGroupGridCell(tc.g, 30)
+			got := strings.Count(cell, "\n") + 1
+			if got != wantLines {
+				t.Errorf("renderGroupGridCell(%s) produced %d lines, want %d\ncell:\n%s",
+					tc.name, got, wantLines, cell)
+			}
+		})
+	}
+}
+
+// TestRenderGroupGrid_RowHeightInvariant covers the row-4 gap reported on
+// macOS Terminal under #158: every visual row of cells must occupy the same
+// number of lines, even when groups in different rows carry different team
+// counts. This is the property that prevents the bordered grid from drifting
+// vertically when FotMob ships unusual qualifier shapes.
+func TestRenderGroupGrid_RowHeightInvariant(t *testing.T) {
+	mkGroup := func(letter string, n int) api.WCGroup {
+		teams := make([]api.LeagueTableEntry, n)
+		for i := range teams {
+			teams[i] = api.LeagueTableEntry{
+				Position: i + 1,
+				Team:     api.Team{Name: "Team" + letter, ShortName: "TM" + letter},
+				Points:   0,
+			}
+		}
+		return api.WCGroup{ID: 100 + int(letter[0]), Letter: letter, Name: "Group " + letter, Teams: teams}
+	}
+
+	letters := []string{"A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L"}
+	groups := make([]api.WCGroup, len(letters))
+	for i, l := range letters {
+		// Simulate FotMob shipping an extra placeholder team in the last
+		// row of groups, which is the pattern that triggered the report.
+		n := 4
+		if i >= 9 {
+			n = 5
+		}
+		groups[i] = mkGroup(l, n)
+	}
+	wc := &api.WorldCupData{Name: "Test WC", Groups: groups}
+
+	out := RenderGroupGrid(120, 60, wc, 0, "")
+	lines := strings.Split(out, "\n")
+
+	var rowHeights []int
+	start := -1
+	for i, line := range lines {
+		if strings.Contains(line, "┌") && start < 0 {
+			start = i
+		}
+		if strings.Contains(line, "└") && start >= 0 {
+			rowHeights = append(rowHeights, i-start+1)
+			start = -1
+		}
+	}
+	if len(rowHeights) < 4 {
+		t.Fatalf("expected at least 4 grid rows, got %d (heights: %v)\noutput:\n%s",
+			len(rowHeights), rowHeights, out)
+	}
+	for i := 1; i < len(rowHeights); i++ {
+		if rowHeights[i] != rowHeights[0] {
+			t.Errorf("grid row %d height = %d, row 0 height = %d (all heights: %v)",
+				i, rowHeights[i], rowHeights[0], rowHeights)
+		}
+	}
+}

--- a/internal/ui/worldcup/groups_test.go
+++ b/internal/ui/worldcup/groups_test.go
@@ -108,6 +108,65 @@ func TestRenderGroupGridCell_WidthInvariant(t *testing.T) {
 	}
 }
 
+// TestPadToHeight covers the fix-screen-leak helper from #158: every WC
+// render now passes through padToHeight so the returned frame matches the
+// terminal height exactly. Bubbletea's diffing model can leave residue from
+// a previous, taller view at the bottom of a shorter frame; pinning frame
+// height removes that whole class of bug.
+func TestPadToHeight(t *testing.T) {
+	tests := []struct {
+		name      string
+		in        string
+		height    int
+		wantLines int
+	}{
+		{"pads short to height", "a\nb", 5, 5},
+		{"truncates tall to height", "a\nb\nc\nd\ne\nf", 3, 3},
+		{"matches exact height", "a\nb\nc", 3, 3},
+		{"zero height returns input", "a\nb", 0, 2},
+		{"negative height returns input", "a\nb", -1, 2},
+		{"empty input pads to height", "", 4, 4},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := padToHeight(tc.in, tc.height)
+			gotLines := strings.Count(got, "\n") + 1
+			if gotLines != tc.wantLines {
+				t.Errorf("padToHeight(%q, %d) produced %d lines, want %d",
+					tc.in, tc.height, gotLines, tc.wantLines)
+			}
+		})
+	}
+}
+
+func TestRenderGroupGrid_FrameHeightInvariant(t *testing.T) {
+	mkGroup := func(letter string) api.WCGroup {
+		return api.WCGroup{
+			ID: int(letter[0]), Letter: letter, Name: "Group " + letter,
+			Teams: []api.LeagueTableEntry{
+				{Position: 1, Team: api.Team{Name: "Team", ShortName: "TM" + letter}, Points: 0},
+				{Position: 2, Team: api.Team{Name: "Team", ShortName: "TM" + letter}, Points: 0},
+				{Position: 3, Team: api.Team{Name: "Team", ShortName: "TM" + letter}, Points: 0},
+				{Position: 4, Team: api.Team{Name: "Team", ShortName: "TM" + letter}, Points: 0},
+			},
+		}
+	}
+	wc := &api.WorldCupData{Name: "Test", Groups: []api.WCGroup{mkGroup("A"), mkGroup("B"), mkGroup("C"), mkGroup("D")}}
+
+	const wantH = 40
+	out := RenderGroupGrid(120, wantH, wc, 0, "")
+	got := strings.Count(out, "\n") + 1
+	if got != wantH {
+		t.Errorf("RenderGroupGrid produced %d lines, want %d", got, wantH)
+	}
+
+	out2 := RenderGroupDetail(120, wantH, wc, 0, "")
+	got2 := strings.Count(out2, "\n") + 1
+	if got2 != wantH {
+		t.Errorf("RenderGroupDetail produced %d lines, want %d", got2, wantH)
+	}
+}
+
 // TestRenderGroupGridCell_FixedHeight locks in the fix for the row-4 gap
 // reported on macOS Terminal under #158: every cell must render at exactly
 // 1 + gridCellTeamRows lines regardless of how many teams FotMob ships.

--- a/internal/ui/worldcup/groups_test.go
+++ b/internal/ui/worldcup/groups_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/0xjuanma/golazo/internal/api"
+	"github.com/charmbracelet/lipgloss"
 )
 
 func sampleGroup() api.WCGroup {
@@ -67,5 +68,42 @@ func TestRenderGroupStandingsTable_EmojiAdjacentToName(t *testing.T) {
 	// Unmapped short code still appears as the bare code (no flag).
 	if !strings.Contains(table, "ZZZ") {
 		t.Errorf("expected unmapped short code ZZZ in table, got:\n%s", table)
+	}
+}
+
+// TestRenderGroupGridCell_WidthInvariant locks in the fix for #158: every
+// team row inside a grid cell must occupy the same visual width regardless
+// of whether the label uses a regional-indicator flag, a tag-sequence
+// subdivision flag, or a placeholder. Without the width pin in
+// renderGroupGridCell, the v0.27.0 flag/name-override backfill caused rows
+// to drift in terminals whose width metric disagrees with lipgloss.
+func TestRenderGroupGridCell_WidthInvariant(t *testing.T) {
+	mixed := api.WCGroup{
+		ID: 1, Letter: "M", Name: "Group M",
+		Teams: []api.LeagueTableEntry{
+			// Regional-indicator pair
+			{Position: 1, Team: api.Team{Name: "Mexico", ShortName: "MEX"}, Points: 9},
+			// Tag-sequence subdivision flag
+			{Position: 2, Team: api.Team{Name: "England", ShortName: "ENG"}, Points: 6},
+			// Override-fallback (ambiguous SOU → KOR)
+			{Position: 3, Team: api.Team{Name: "South Korea", ShortName: "SOU"}, Points: 4},
+			// No-flag placeholder
+			{Position: 4, Team: api.Team{Name: "Nowhereland", ShortName: "ZZZ"}, Points: 0},
+		},
+	}
+
+	cell := renderGroupGridCell(mixed, 30)
+	rows := strings.Split(cell, "\n")
+	if len(rows) < 5 {
+		t.Fatalf("expected header + 4 team rows, got %d lines:\n%s", len(rows), cell)
+	}
+
+	teamRows := rows[1:]
+	wantW := lipgloss.Width(teamRows[0])
+	for i, row := range teamRows {
+		if w := lipgloss.Width(row); w != wantW {
+			t.Errorf("row %d width mismatch: got %d, want %d\nrow=%q\nfull cell:\n%s",
+				i, w, wantW, row, cell)
+		}
 	}
 }

--- a/internal/ui/worldcup/styles.go
+++ b/internal/ui/worldcup/styles.go
@@ -106,17 +106,27 @@ var (
 				Foreground(colorRed).
 				Bold(true)
 
+	// GridSelectedGroupHeaderStyle is rendered in cyan to mark the focused
+	// cell. The grid intentionally avoids box-drawing borders because their
+	// visual width disagrees between terminals when neighboring cells carry
+	// flag emojis (#158); a colored header is terminal-independent.
+	GridSelectedGroupHeaderStyle = lipgloss.NewStyle().
+					Foreground(colorCyan).
+					Bold(true).
+					Underline(true)
+
 	GridTeamQualStyle  = lipgloss.NewStyle().Foreground(colorCyan)
 	GridTeamThirdStyle = lipgloss.NewStyle().Foreground(colorGold)
 	GridTeamDimStyle   = lipgloss.NewStyle().Foreground(colorDim)
 
+	// GridSelectedGroupStyle and GridNormalGroupStyle now use interior
+	// padding only — no border — so per-cell visual width never depends on
+	// terminal-specific box-drawing measurements.
 	GridSelectedGroupStyle = lipgloss.NewStyle().
-				Border(lipgloss.NormalBorder()).
-				BorderForeground(colorRed)
+				Padding(0, 1)
 
 	GridNormalGroupStyle = lipgloss.NewStyle().
-				Border(lipgloss.NormalBorder()).
-				BorderForeground(colorDim)
+				Padding(0, 1)
 )
 
 // alignRight renders text right-aligned in a fixed-width column.

--- a/internal/ui/worldcup/team_label.go
+++ b/internal/ui/worldcup/team_label.go
@@ -4,7 +4,14 @@ import (
 	"strings"
 
 	"github.com/0xjuanma/golazo/internal/api"
+	"github.com/mattn/go-runewidth"
 )
+
+// labelTargetWidth is the visual width every team label is padded to so rows
+// align across all WC views regardless of which resolution branch produced
+// the label or how the terminal measures regional-indicator / tag-sequence
+// flag clusters. Matches "   XYZ" (3-cell placeholder + 3-letter code).
+const labelTargetWidth = 6
 
 // TeamLabel returns the consistent World Cup display label for a team:
 // "<flag-emoji> <CODE>", where <CODE> is the FIFA 3-letter abbreviation.
@@ -75,16 +82,33 @@ func capCode(c string) string {
 	return c
 }
 
-// labelWithFlag renders "<emoji> <CODE>", padding the emoji slot with two
-// spaces when no flag is registered so columns line up across rows.
+// labelWithFlag renders "<emoji> <CODE>", padding to a fixed visual width so
+// every row aligns regardless of (a) whether the resolved code has a
+// registered flag and (b) how the terminal measures the emoji cluster. The
+// no-flag branch reserves a 3-cell placeholder so columns match the with-flag
+// branch under any width-table assumption.
 func labelWithFlag(code string) string {
 	if code == "" {
-		return "   " // 3-cell placeholder consistent with emoji + space slot
+		return padToLabelWidth("   ")
 	}
 	if emoji := FlagEmoji(code); emoji != "" {
-		return emoji + " " + code
+		return padToLabelWidth(emoji + " " + code)
 	}
-	return "   " + code
+	return padToLabelWidth("   " + code)
+}
+
+// padToLabelWidth right-pads s with spaces until its visual width matches
+// labelTargetWidth under runewidth's tables. lipgloss is consulted as a
+// second check so labels stay consistent between width metrics; whichever
+// table reports the larger width drives the padding floor, and the smaller
+// metric is filled to match. Strings already wider than the target are
+// returned unchanged.
+func padToLabelWidth(s string) string {
+	w := runewidth.StringWidth(s)
+	if w >= labelTargetWidth {
+		return s
+	}
+	return s + strings.Repeat(" ", labelTargetWidth-w)
 }
 
 // wcNameToCode covers WC teams whose FotMob payloads sometimes ship a full

--- a/internal/ui/worldcup/team_label_test.go
+++ b/internal/ui/worldcup/team_label_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/0xjuanma/golazo/internal/api"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/mattn/go-runewidth"
 )
 
 func TestTeamLabel(t *testing.T) {
@@ -76,8 +78,14 @@ func TestTeamLabel(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := TeamLabel(tt.team); got != tt.want {
-				t.Errorf("TeamLabel(%+v) = %q, want %q", tt.team, got, tt.want)
+			got := TeamLabel(tt.team)
+			if !strings.HasPrefix(got, tt.want) {
+				t.Errorf("TeamLabel(%+v) = %q, want prefix %q", tt.team, got, tt.want)
+			}
+			if !strings.HasPrefix(strings.TrimRight(got, " "), tt.want) &&
+				strings.TrimRight(got, " ") != tt.want {
+				t.Errorf("TeamLabel(%+v) trimmed = %q, want %q",
+					tt.team, strings.TrimRight(got, " "), tt.want)
 			}
 		})
 	}
@@ -104,8 +112,10 @@ func TestMatchupTeamLabel(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := MatchupTeamLabel(tt.short, tt.full, tt.tbd); got != tt.want {
-				t.Errorf("MatchupTeamLabel(%q, %q, %v) = %q, want %q",
+			got := MatchupTeamLabel(tt.short, tt.full, tt.tbd)
+			trimmed := strings.TrimRight(got, " ")
+			if trimmed != tt.want && !strings.HasPrefix(got, tt.want) {
+				t.Errorf("MatchupTeamLabel(%q, %q, %v) = %q, want %q (or padded)",
 					tt.short, tt.full, tt.tbd, got, tt.want)
 			}
 		})
@@ -162,9 +172,45 @@ func TestTeamLabel_WC2026Qualifiers(t *testing.T) {
 				t.Fatalf("missing flagEmojis entry for %s (%s)", tc.name, tc.code)
 			}
 			got := TeamLabel(api.Team{Name: tc.name})
-			want := flag + " " + tc.code
-			if got != want {
-				t.Errorf("TeamLabel({Name:%q}) = %q, want %q", tc.name, got, want)
+			wantPrefix := flag + " " + tc.code
+			if !strings.HasPrefix(got, wantPrefix) {
+				t.Errorf("TeamLabel({Name:%q}) = %q, want prefix %q", tc.name, got, wantPrefix)
+			}
+		})
+	}
+}
+
+// TestLabelWidthInvariant locks in the fix for #158: every team label must
+// occupy the same visual width regardless of which resolution branch
+// produced it. Without padding, with-flag labels measure 5 cells under
+// runewidth's tables while placeholder labels measure 6, which caused
+// per-row drift in terminals following the legacy width table after the
+// v0.27.0 flag/name-override backfill.
+func TestLabelWidthInvariant(t *testing.T) {
+	probes := []api.Team{
+		// Registered flag (regional indicator pair)
+		{Name: "Mexico", ShortName: "MEX"},
+		{Name: "Brazil", ShortName: "BRA"},
+		{Name: "South Korea", ShortName: "SOU"}, // exercises override fallback
+		// Registered flag (tag-sequence subdivision)
+		{Name: "England", ShortName: "ENG"},
+		{Name: "Wales", ShortName: "WAL"},
+		{Name: "Scotland", ShortName: "SCO"},
+		// No registered flag → placeholder branch
+		{Name: "Nowhereland", ShortName: "ZZZ"},
+		{Name: "Nowhereland", ShortName: ""},
+	}
+
+	for _, team := range probes {
+		t.Run(team.Name+"/"+team.ShortName, func(t *testing.T) {
+			label := TeamLabel(team)
+			if w := runewidth.StringWidth(label); w != labelTargetWidth {
+				t.Errorf("runewidth.StringWidth(%q) = %d, want %d",
+					label, w, labelTargetWidth)
+			}
+			if w := lipgloss.Width(label); w < labelTargetWidth {
+				t.Errorf("lipgloss.Width(%q) = %d, want >= %d",
+					label, w, labelTargetWidth)
 			}
 		})
 	}

--- a/internal/ui/worldcup/upcoming.go
+++ b/internal/ui/worldcup/upcoming.go
@@ -48,7 +48,7 @@ func RenderUpcoming(width, height int, matches []api.Match, loading bool, lastEr
 		parts = append(parts, statusBanner)
 	}
 	parts = append(parts, header, "", body, help)
-	return lipgloss.JoinVertical(lipgloss.Left, parts...)
+	return padToHeight(lipgloss.JoinVertical(lipgloss.Left, parts...), height)
 }
 
 // renderWCUpcomingMatches groups matches by local kickoff date and renders


### PR DESCRIPTION
## Summary
Reworks the World Cup grid to render consistently across terminals after the v0.27.0 flag/name backfill, and clears stale frame content when navigating between WC sub-views.

## Updates
- Equalize team label visual width across all flag and placeholder branches so rows align under any terminal width metric
- Drop cell borders in favor of a borderless grid with colored selection, eliminating cross-terminal border drift
- Pin every WC render to terminal height and issue ClearScreen on sub-view transitions to prevent frame leaks
- Drop FotMob pseudo-tables and empty placeholder rows from the WC group parser

Closes #158