### PR TITLE
feat[data/settings]: add AFC Champions League Two

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **AFC Champions League Two** - Added the AFC Champions League Two (FotMob ID 9469) to the supported leagues list under the Asia region.
 
 ### Changed
 - **Reddit goal-link retrieval** — improved coverage for World Cup and national-team matches, with looser team and scorer name matching across spellings, diacritics, and common r/soccer title formats.

--- a/docs/SUPPORTED_LEAGUES.md
+++ b/docs/SUPPORTED_LEAGUES.md
@@ -128,6 +128,7 @@ Golazo supports **65+ leagues and competitions**. Customize your selection in Se
 | | League/Competition |
 |---|-------------------|
 | 🏆 | AFC Champions League Elite |
+| 🏆 | AFC Champions League Two |
 | 🇨🇳 | Chinese Super League |
 | 🇮🇳 | Indian Super League |
 | 🇯🇵 | J. League |

--- a/internal/data/settings.go
+++ b/internal/data/settings.go
@@ -128,6 +128,7 @@ var AllSupportedLeagues = map[string][]LeagueInfo{
 		{ID: 536, Name: "Saudi Pro League", Country: "Saudi Arabia"},
 		// Asia
 		{ID: 525, Name: "AFC Champions League Elite", Country: "Asia"},
+		{ID: 9469, Name: "AFC Champions League Two", Country: "Asia"},
 		{ID: 9478, Name: "Indian Super League", Country: "India"},
 		{ID: 223, Name: "J. League", Country: "Japan"},
 		{ID: 9080, Name: "K League 1", Country: "South Korea"},


### PR DESCRIPTION
## Summary
Resolves https://github.com/0xjuanma/golazo/issues/164. Adds the AFC Champions League Two (FotMob ID 9469) to the supported leagues under the Asia region.

## Updates
- Registered league 9469 in `AllSupportedLeagues` and noted it in the Asia table