### PR TITLE
feat[ui/worldcup]: polish group grid selection and upcoming round labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **Reddit goal-link retrieval** — improved coverage for World Cup and national-team matches, with looser team and scorer name matching across spellings, diacritics, and common r/soccer title formats.
+- **UI Refinements** — minor visual tweaks improving focus indicators and overall consistency.
 
 ### Fixed
 

--- a/internal/ui/worldcup/groups.go
+++ b/internal/ui/worldcup/groups.go
@@ -359,15 +359,18 @@ func padToHeight(s string, height int) string {
 // FotMob ships per group (4 in normal play, occasionally more in qualifier
 // formats or alongside playoff annotations).
 //
-// Selection is conveyed by switching the title color instead of drawing a
+// Selection is conveyed by swapping the plain red title for the gradient
+// "compact header" (gradient text + diagonal `╱` fill) instead of drawing a
 // border, because box-drawing characters disagree with neighboring cells'
-// flag-emoji widths across terminals (#158).
+// flag-emoji widths across terminals (#158). The diagonal fill is pure
+// ASCII-width and renders consistently across terminals.
 func renderGroupGridCell(g api.WCGroup, width int, selected bool) string {
-	titleStyle := GridGroupHeaderStyle
+	var title string
 	if selected {
-		titleStyle = GridSelectedGroupHeaderStyle
+		title = design.RenderHeader(g.Name, width)
+	} else {
+		title = GridGroupHeaderStyle.Render(g.Name)
 	}
-	title := titleStyle.Render(g.Name)
 	lines := []string{title}
 	// labelTargetWidth is the visual budget every TeamLabel is padded to;
 	// add 1 cell of trailing breathing room before the points column.

--- a/internal/ui/worldcup/round_label.go
+++ b/internal/ui/worldcup/round_label.go
@@ -1,0 +1,35 @@
+package worldcup
+
+import "strings"
+
+// roundLabels maps the bare round identifiers FotMob ships on the fixtures
+// endpoint to human-readable display strings for the World Cup upcoming view.
+//
+// FotMob emits numeric matchday strings ("1", "2", "3") during the group stage
+// and short codes ("R32", "R16", "QF", "SF", "3RD", "FINAL") for the knockout
+// rounds. The verbose labels below match the World Cup 2026 48-team format.
+var roundLabels = map[string]string{
+	"1":     "Group Stage · MD1",
+	"2":     "Group Stage · MD2",
+	"3":     "Group Stage · MD3",
+	"R32":   "Round of 32",
+	"R16":   "Round of 16",
+	"QF":    "Quarter-finals",
+	"SF":    "Semi-finals",
+	"3RD":   "Third Place Play-off",
+	"FINAL": "Final",
+}
+
+// roundLabel returns a human-readable label for the given FotMob round value.
+// Lookup is case-insensitive against roundLabels; unknown values are returned
+// verbatim so descriptive labels coming from other code paths (e.g. mock
+// fixtures shipping "Group A") still render unchanged.
+func roundLabel(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	if label, ok := roundLabels[strings.ToUpper(raw)]; ok {
+		return label
+	}
+	return raw
+}

--- a/internal/ui/worldcup/round_label_test.go
+++ b/internal/ui/worldcup/round_label_test.go
@@ -1,0 +1,32 @@
+package worldcup
+
+import "testing"
+
+func TestRoundLabel(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want string
+	}{
+		{"1", "Group Stage · MD1"},
+		{"2", "Group Stage · MD2"},
+		{"3", "Group Stage · MD3"},
+		{"R32", "Round of 32"},
+		{"r16", "Round of 16"},
+		{"qf", "Quarter-finals"},
+		{"SF", "Semi-finals"},
+		{"3RD", "Third Place Play-off"},
+		{"final", "Final"},
+		{"", ""},
+		// Unknown values pass through verbatim so the mock fixtures' "Group A"
+		// labels (and any future FotMob value we haven't mapped yet) still
+		// render rather than getting swallowed.
+		{"Group A", "Group A"},
+		{"Play-off", "Play-off"},
+	}
+
+	for _, tc := range cases {
+		if got := roundLabel(tc.raw); got != tc.want {
+			t.Errorf("roundLabel(%q) = %q, want %q", tc.raw, got, tc.want)
+		}
+	}
+}

--- a/internal/ui/worldcup/styles.go
+++ b/internal/ui/worldcup/styles.go
@@ -106,14 +106,10 @@ var (
 				Foreground(colorRed).
 				Bold(true)
 
-	// GridSelectedGroupHeaderStyle is rendered in cyan to mark the focused
-	// cell. The grid intentionally avoids box-drawing borders because their
-	// visual width disagrees between terminals when neighboring cells carry
-	// flag emojis (#158); a colored header is terminal-independent.
-	GridSelectedGroupHeaderStyle = lipgloss.NewStyle().
-					Foreground(colorCyan).
-					Bold(true).
-					Underline(true)
+	// Selection is conveyed by swapping this plain red title for the
+	// gradient "compact header" (see design.RenderHeader) rather than a
+	// border, because box-drawing characters disagree with neighboring
+	// cells' flag-emoji widths across terminals (#158).
 
 	GridTeamQualStyle  = lipgloss.NewStyle().Foreground(colorCyan)
 	GridTeamThirdStyle = lipgloss.NewStyle().Foreground(colorGold)

--- a/internal/ui/worldcup/upcoming.go
+++ b/internal/ui/worldcup/upcoming.go
@@ -88,7 +88,7 @@ func renderWCUpcomingMatches(matches []api.Match) string {
 		line := fmt.Sprintf("  %s  %s %s %s", timeStr, home, vsStyle.Render("vs"), away)
 
 		if m.Round != "" {
-			line += "  " + roundStyle.Render(m.Round)
+			line += "  " + roundStyle.Render(roundLabel(m.Round))
 		}
 		lines = append(lines, line)
 	}


### PR DESCRIPTION
## Summary
Polish the World Cup views: selected group cells now use the gradient compact header, and upcoming-match round codes render as readable stage labels.

## Updates
- Render selected group title as gradient compact header
- Map FotMob round codes (matchday / R32 / QF / SF / 3RD / FINAL) to verbose stage labels