### PR TITLE
feat[reddit]: paced goal-link queue with reddit block recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **Caching** — FotMob league page bodies are now cached for 60s and shared across the live, stats, World Cup, and standings views, reducing redundant network calls during quick navigation.
+- **Reddit goal-link retrieval** — goal replay links now load one-by-one in the match panel and recover gracefully when Reddit rate-limits the app, instead of all attempts failing in a burst.
 
 ### Fixed
 - **Live matches view** — matches that kicked off before the user's UTC midnight (e.g. evening kickoffs for users in the Americas) are no longer dropped from the Live view.

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -362,31 +362,52 @@ func fetchStatsMatchDetailsFotmob(client *fotmob.Client, matchID int, useMockDat
 	}
 }
 
-// fetchGoalLinks fetches goal replay links from Reddit for all goals in a match.
-// This is called on-demand when match details are loaded/displayed.
-// Links are cached persistently to avoid redundant API calls.
+// fetchGoalLinks opens a streaming subscription to the reddit queue for all
+// goals in `details`. Returns a tea.Cmd that emits a goalLinkStreamMsg
+// carrying the result channel; the Update loop stashes the channel and arms
+// successive waitForGoalLink reader Cmds at the queue's cadence.
+//
+// Goals already in the persistent cache surface immediately (they're written
+// into the channel by GoalLinksAsync before queueing begins); uncached goals
+// arrive at QueueInterval cadence. Each emitted goalLinkMsg carries a single
+// result so the UI updates progressively instead of waiting for the entire
+// match's goals to resolve.
 func fetchGoalLinks(redditClient *reddit.Client, details *api.MatchDetails) tea.Cmd {
+	if redditClient == nil || details == nil {
+		return nil
+	}
+
+	goals := buildGoalInfos(details)
+	if len(goals) == 0 {
+		return nil
+	}
+
+	// Log the per-goal running scores so the corrected matcher inputs are
+	// observable in golazo_debug.log without trawling individual search
+	// queries. Useful for verifying World Cup / national-team retrievals.
+	redditClient.DebugLog(fmt.Sprintf("fetchGoalLinks: match=%d %s vs %s — %d goals: %s",
+		details.ID, details.HomeTeam.Name, details.AwayTeam.Name, len(goals),
+		formatGoalSummary(goals)))
+
+	matchID := details.ID
+	results := redditClient.GoalLinksAsync(goals)
+
 	return func() tea.Msg {
-		if redditClient == nil || details == nil {
-			return goalLinksMsg{matchID: 0, links: nil}
+		return goalLinkStreamMsg{matchID: matchID, ch: results}
+	}
+}
+
+// waitForGoalLink returns a tea.Cmd that blocks until the next GoalResult
+// arrives on results (or the channel closes), then emits a goalLinkMsg or a
+// terminal goalLinksDoneMsg. The Update handler re-arms this Cmd after each
+// goalLinkMsg, forming the subscription loop.
+func waitForGoalLink(matchID int, results <-chan reddit.GoalResult) tea.Cmd {
+	return func() tea.Msg {
+		r, ok := <-results
+		if !ok {
+			return goalLinksDoneMsg{matchID: matchID}
 		}
-
-		goals := buildGoalInfos(details)
-		if len(goals) == 0 {
-			return goalLinksMsg{matchID: details.ID, links: nil}
-		}
-
-		// Log the per-goal running scores so the corrected matcher inputs are
-		// observable in golazo_debug.log without trawling individual search
-		// queries. Useful for verifying World Cup / national-team retrievals.
-		redditClient.DebugLog(fmt.Sprintf("fetchGoalLinks: match=%d %s vs %s — %d goals: %s",
-			details.ID, details.HomeTeam.Name, details.AwayTeam.Name, len(goals),
-			formatGoalSummary(goals)))
-
-		// Fetch links for all goals (uses cache internally)
-		links := redditClient.GoalLinks(goals)
-
-		return goalLinksMsg{matchID: details.ID, links: links}
+		return goalLinkMsg{matchID: matchID, key: r.Key, link: r.Link}
 	}
 }
 

--- a/internal/app/commands_test.go
+++ b/internal/app/commands_test.go
@@ -1,11 +1,21 @@
 package app
 
 import (
+	"io"
+	"log/slog"
 	"testing"
 	"time"
 
 	"github.com/0xjuanma/golazo/internal/api"
+	"github.com/0xjuanma/golazo/internal/reddit"
 )
+
+// testLogger returns a slog.Logger that discards output, matching the
+// debugLog-disabled path of initLogger. Required because handleGoalLink
+// calls m.debugLog which panics with nil m.logger.
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
 
 func TestBuildGoalInfosRunningScore(t *testing.T) {
 	home := api.Team{ID: 1, Name: "Australia", ShortName: "AUS"}
@@ -143,5 +153,63 @@ func TestBuildGoalInfosNoGoalsReturnsNil(t *testing.T) {
 func TestBuildGoalInfosNilDetails(t *testing.T) {
 	if got := buildGoalInfos(nil); got != nil {
 		t.Errorf("expected nil for nil details, got %d goals", len(got))
+	}
+}
+
+// TestHandleGoalLinkMergesSingle exercises the per-goal merge that the
+// subscription path relies on: a single goalLinkMsg must be applied to
+// m.goalLinks[key] and the reader Cmd must be re-armed against the same
+// channel. The behavior under test is the merge inside handleGoalLink — not
+// any wrapping fetch logic — so the test wires a channel directly without
+// invoking GoalLinksAsync.
+func TestHandleGoalLinkMergesSingle(t *testing.T) {
+	ch := make(chan reddit.GoalResult, 1)
+	defer close(ch)
+
+	m := model{
+		goalLinks:     make(map[reddit.GoalLinkKey]*reddit.GoalLink),
+		goalLinkChans: map[int]<-chan reddit.GoalResult{42: ch},
+		logger:        testLogger(),
+	}
+
+	link := &reddit.GoalLink{
+		MatchID: 42,
+		Minute:  17,
+		URL:     "https://example.com/replay",
+		Title:   "Iran 0 - [1] New Zealand - E. Just 7'",
+	}
+	key := reddit.GoalLinkKey{MatchID: 42, Minute: 17}
+
+	newModel, cmd := m.handleGoalLink(goalLinkMsg{matchID: 42, key: key, link: link})
+	mm, ok := newModel.(model)
+	if !ok {
+		t.Fatalf("handleGoalLink returned wrong model type: %T", newModel)
+	}
+	if got := mm.goalLinks[key]; got != link {
+		t.Errorf("goalLinks[%+v] = %+v, want %+v", key, got, link)
+	}
+	if cmd == nil {
+		t.Fatal("handleGoalLink returned nil Cmd; expected re-armed waitForGoalLink")
+	}
+}
+
+// TestHandleGoalLinkNotFoundIsRecorded verifies that nil/not-found results
+// are still stored in goalLinks so the UI can distinguish "search resolved
+// to no match" from "search still pending".
+func TestHandleGoalLinkNotFoundIsRecorded(t *testing.T) {
+	ch := make(chan reddit.GoalResult, 1)
+	defer close(ch)
+
+	m := model{
+		goalLinks:     make(map[reddit.GoalLinkKey]*reddit.GoalLink),
+		goalLinkChans: map[int]<-chan reddit.GoalResult{99: ch},
+		logger:        testLogger(),
+	}
+	key := reddit.GoalLinkKey{MatchID: 99, Minute: 45}
+
+	newModel, _ := m.handleGoalLink(goalLinkMsg{matchID: 99, key: key, link: nil})
+	mm := newModel.(model)
+	if _, ok := mm.goalLinks[key]; !ok {
+		t.Errorf("expected nil-link sentinel entry in goalLinks for %+v", key)
 	}
 }

--- a/internal/app/messages.go
+++ b/internal/app/messages.go
@@ -66,13 +66,6 @@ type pollTickMsg struct {
 // This allows the "Updating..." spinner to be visible for at least 1 second.
 type pollDisplayCompleteMsg struct{}
 
-// goalLinksMsg contains goal replay links fetched from Reddit.
-// Sent after searching r/soccer for Media posts matching goal events.
-type goalLinksMsg struct {
-	matchID int
-	links   map[reddit.GoalLinkKey]*reddit.GoalLink
-}
-
 // goalLinkStreamMsg hands a freshly-opened goal-link subscription channel to
 // the Update loop. The handler stashes the channel on the model (keyed by
 // matchID) and arms the first reader Cmd. Emitted once per match-details

--- a/internal/app/messages.go
+++ b/internal/app/messages.go
@@ -73,6 +73,36 @@ type goalLinksMsg struct {
 	links   map[reddit.GoalLinkKey]*reddit.GoalLink
 }
 
+// goalLinkStreamMsg hands a freshly-opened goal-link subscription channel to
+// the Update loop. The handler stashes the channel on the model (keyed by
+// matchID) and arms the first reader Cmd. Emitted once per match-details
+// load, before any goalLinkMsg for that match.
+type goalLinkStreamMsg struct {
+	matchID int
+	ch      <-chan reddit.GoalResult
+}
+
+// goalLinkMsg streams a single goal-link outcome from the reddit queue's
+// subscription channel. The match-level goalLinksMsg above remains for
+// initial cache-hit batches; goalLinkMsg carries per-goal results that
+// arrive at the queue's 30s cadence so the UI can render replay links
+// progressively instead of waiting for the entire match's goals to resolve.
+// Link is nil when the goal was searched but not found, was dropped because
+// Reddit returned ErrBlocked, or hit a transient fetch error.
+type goalLinkMsg struct {
+	matchID int
+	key     reddit.GoalLinkKey
+	link    *reddit.GoalLink
+}
+
+// goalLinksDoneMsg signals that the reddit queue's subscription channel for
+// a given match has closed — every queued goal has produced exactly one
+// goalLinkMsg. Used to stop the subscription tea.Cmd loop without leaking
+// goroutines.
+type goalLinksDoneMsg struct {
+	matchID int
+}
+
 // standingsMsg contains league standings from API response.
 // Used to populate the standings dialog.
 type standingsMsg struct {

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -159,6 +159,13 @@ type model struct {
 	// Goal replay links from Reddit (keyed by matchID:minute)
 	goalLinks map[reddit.GoalLinkKey]*reddit.GoalLink
 
+	// Active goal-link subscriptions keyed by matchID. The reddit client's
+	// GoalLinksAsync streams one GoalResult per goal at the queue's cadence;
+	// the Update loop drives a reader Cmd that re-arms from the same
+	// channel until it closes. Stored on the model so handleGoalLink can
+	// re-issue a wait Cmd without losing the channel reference.
+	goalLinkChans map[int]<-chan reddit.GoalResult
+
 	// Logging
 	logger  *slog.Logger
 	logFile *os.File // kept open for logger lifetime
@@ -280,6 +287,7 @@ func New(useMockData bool, debugMode bool, isDevBuild bool, newVersionAvailable 
 		parser:                 fotmob.NewLiveUpdateParser(),
 		redditClient:           redditClient,
 		goalLinks:              make(map[reddit.GoalLinkKey]*reddit.GoalLink),
+		goalLinkChans:          make(map[int]<-chan reddit.GoalResult),
 		logger:                 logger,
 		logFile:                logFile,
 		notifier:               notify.NewDesktopNotifier(),

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -66,9 +66,6 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Route filter matches message to the appropriate list based on current view
 		return m.handleFilterMatches(msg)
 
-	case goalLinksMsg:
-		return m.handleGoalLinks(msg)
-
 	case goalLinkStreamMsg:
 		return m.handleGoalLinkStream(msg)
 
@@ -1296,40 +1293,6 @@ func max(a, b int) int {
 		return a
 	}
 	return b
-}
-
-// handleGoalLinks processes goal replay links fetched from Reddit.
-func (m model) handleGoalLinks(msg goalLinksMsg) (tea.Model, tea.Cmd) {
-	m.debugLog(fmt.Sprintf("handleGoalLinks called for match %d with %d links", msg.matchID, len(msg.links)))
-	if len(msg.links) == 0 {
-		m.debugLog(fmt.Sprintf("GoalLinks completed for match %d: no links found", msg.matchID))
-		return m, nil
-	}
-
-	m.debugLog(fmt.Sprintf("GoalLinks completed for match %d: processing %d links", msg.matchID, len(msg.links)))
-
-	// Merge new links into the goal links map
-	if m.goalLinks == nil {
-		m.goalLinks = make(map[reddit.GoalLinkKey]*reddit.GoalLink)
-	}
-
-	validLinks := 0
-	failedLinks := 0
-
-	for key, link := range msg.links {
-		m.goalLinks[key] = link
-		if link != nil && link.URL != "" && link.URL != "__NOT_FOUND__" {
-			validLinks++
-			m.debugLog(fmt.Sprintf("Cached goal link: %d:%d → %s (post: %s)", key.MatchID, key.Minute, link.URL, link.PostURL))
-		} else if link != nil && link.URL == "__NOT_FOUND__" {
-			failedLinks++
-			m.debugLog(fmt.Sprintf("No link found: %d:%d", key.MatchID, key.Minute))
-		}
-	}
-
-	m.debugLog(fmt.Sprintf("Goal link batch complete: %d valid, %d failed", validLinks, failedLinks))
-
-	return m, nil
 }
 
 // handleGoalLinkStream stashes a freshly-opened goal-link subscription

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -69,6 +69,15 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case goalLinksMsg:
 		return m.handleGoalLinks(msg)
 
+	case goalLinkStreamMsg:
+		return m.handleGoalLinkStream(msg)
+
+	case goalLinkMsg:
+		return m.handleGoalLink(msg)
+
+	case goalLinksDoneMsg:
+		return m.handleGoalLinksDone(msg)
+
 	case standingsMsg:
 		return m.handleStandings(msg)
 
@@ -1320,6 +1329,58 @@ func (m model) handleGoalLinks(msg goalLinksMsg) (tea.Model, tea.Cmd) {
 
 	m.debugLog(fmt.Sprintf("Goal link batch complete: %d valid, %d failed", validLinks, failedLinks))
 
+	return m, nil
+}
+
+// handleGoalLinkStream stashes a freshly-opened goal-link subscription
+// channel on the model and arms the first reader Cmd. One stream is tracked
+// per matchID; re-opening for the same match replaces the previous channel
+// (the old reader Cmd will receive a closed-channel signal next read and
+// exit cleanly via goalLinksDoneMsg).
+func (m model) handleGoalLinkStream(msg goalLinkStreamMsg) (tea.Model, tea.Cmd) {
+	if m.goalLinkChans == nil {
+		m.goalLinkChans = make(map[int]<-chan reddit.GoalResult)
+	}
+	m.goalLinkChans[msg.matchID] = msg.ch
+	m.debugLog(fmt.Sprintf("goalLinkStream: opened subscription for match %d", msg.matchID))
+	return m, waitForGoalLink(msg.matchID, msg.ch)
+}
+
+// handleGoalLink merges a single goal-link result into the model's
+// goalLinks map and re-arms the reader Cmd against the same stream. This is
+// where the per-goal behavior change lives: each link is applied
+// individually so the UI re-renders progressively at the queue's cadence.
+func (m model) handleGoalLink(msg goalLinkMsg) (tea.Model, tea.Cmd) {
+	if m.goalLinks == nil {
+		m.goalLinks = make(map[reddit.GoalLinkKey]*reddit.GoalLink)
+	}
+
+	if msg.link != nil && msg.link.URL != "" && msg.link.URL != reddit.NotFoundMarker {
+		m.goalLinks[msg.key] = msg.link
+		m.debugLog(fmt.Sprintf("goalLink: match=%d %d:%d → %s",
+			msg.matchID, msg.key.MatchID, msg.key.Minute, msg.link.URL))
+	} else {
+		// Record nil/not-found so the UI knows the search resolved (vs.
+		// pending) without rendering a broken link.
+		m.goalLinks[msg.key] = msg.link
+		m.debugLog(fmt.Sprintf("goalLink: match=%d %d:%d → no link",
+			msg.matchID, msg.key.MatchID, msg.key.Minute))
+	}
+
+	ch, ok := m.goalLinkChans[msg.matchID]
+	if !ok {
+		// Stream was torn down (e.g., user navigated away) — don't re-arm.
+		return m, nil
+	}
+	return m, waitForGoalLink(msg.matchID, ch)
+}
+
+// handleGoalLinksDone removes the closed subscription channel from the
+// model. Emitted by waitForGoalLink when the reddit queue's result channel
+// for this match has been fully drained.
+func (m model) handleGoalLinksDone(msg goalLinksDoneMsg) (tea.Model, tea.Cmd) {
+	delete(m.goalLinkChans, msg.matchID)
+	m.debugLog(fmt.Sprintf("goalLinkStream: closed subscription for match %d", msg.matchID))
 	return m, nil
 }
 

--- a/internal/reddit/cache.go
+++ b/internal/reddit/cache.go
@@ -17,8 +17,11 @@ const (
 	// 7 days keeps the cache file small while covering recent matches.
 	CacheTTL = 7 * 24 * time.Hour // 7 days
 	// NotFoundTTL defines how long to cache "not found" results.
-	// Shorter than CacheTTL since links might appear later.
-	NotFoundTTL = 5 * time.Minute // 5 minutes
+	// Shorter than CacheTTL since links might appear later. 1h is a balance:
+	// long enough to avoid re-hitting Reddit for the same missing goal within
+	// a single viewing session (queue is paced at 30s/request), short enough
+	// that late-uploaded videos surface on the next app run.
+	NotFoundTTL = 1 * time.Hour
 	// NotFoundMarker is a special URL indicating "searched but not found"
 	NotFoundMarker = "__NOT_FOUND__"
 )

--- a/internal/reddit/cache_test.go
+++ b/internal/reddit/cache_test.go
@@ -1,0 +1,68 @@
+package reddit
+
+import (
+	"testing"
+	"time"
+)
+
+// TestGetNotFoundTTL exercises the TTL comparison inside Get() for not-found
+// markers (cache.go: time.Since(link.FetchedAt) > NotFoundTTL). A marker just
+// under NotFoundTTL must be returned (so we don't re-search), and a marker
+// just past it must be reported as expired (return nil so a retry is allowed).
+// This is the function where the TTL behavior actually lives — bumping the
+// constant without verifying the comparison would not catch a regression.
+func TestGetNotFoundTTL(t *testing.T) {
+	if NotFoundTTL != time.Hour {
+		t.Fatalf("NotFoundTTL = %v, want 1h", NotFoundTTL)
+	}
+
+	cache := &GoalLinkCache{
+		links: make(map[string]GoalLink),
+	}
+
+	const matchID = 12345
+	const minute = 42
+	key := GoalLinkKey{MatchID: matchID, Minute: minute}
+
+	cases := []struct {
+		name      string
+		fetchedAt time.Time
+		wantFound bool
+	}{
+		{
+			name:      "just under TTL returns marker",
+			fetchedAt: time.Now().Add(-(NotFoundTTL - time.Minute)),
+			wantFound: true,
+		},
+		{
+			name:      "just past TTL returns nil (allows retry)",
+			fetchedAt: time.Now().Add(-(NotFoundTTL + time.Minute)),
+			wantFound: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cache.links[makeKey(key)] = GoalLink{
+				MatchID:   matchID,
+				Minute:    minute,
+				URL:       NotFoundMarker,
+				FetchedAt: tc.fetchedAt,
+			}
+
+			got := cache.Get(key)
+			if tc.wantFound {
+				if got == nil {
+					t.Fatalf("Get returned nil for marker aged %v (TTL %v); expected marker", time.Since(tc.fetchedAt), NotFoundTTL)
+				}
+				if !IsNotFound(got) {
+					t.Fatalf("Get returned non-marker entry: %+v", got)
+				}
+				return
+			}
+			if got != nil {
+				t.Fatalf("Get returned %+v for marker aged %v (TTL %v); expected nil", got, time.Since(tc.fetchedAt), NotFoundTTL)
+			}
+		})
+	}
+}

--- a/internal/reddit/client.go
+++ b/internal/reddit/client.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -342,6 +343,22 @@ func (c *Client) searchForGoal(goal GoalInfo) (*GoalLink, error) {
 }
 
 // searchForGoalOnce performs a single search attempt for a goal.
+//
+// Query format: "<home> <homeScore> <awayScore> <away> <scorerLast>".
+// Example for the 7' New Zealand goal in Iran 0-1 New Zealand:
+//
+//	"Iran 0 1 New Zealand Just"
+//
+// This mirrors verbatim the token sequence that appears in r/soccer goal-post
+// titles like "Iran 0 - [1] New Zealand - E. Just 7'" (slug
+// `iran_0_1_new_zealand_e_just_7`). The running score uniquely disambiguates
+// goals within a single match — searching by minute alone is the weakest
+// signal because Reddit's tokenizer handles the apostrophe inconsistently and
+// bare numbers are low-entropy.
+//
+// When ScorerName is empty (own goals, missing data), the scorer token is
+// omitted and matching relies on score + team names. Minute validation lives
+// in findBestMatch via buildMinutePattern.
 func (c *Client) searchForGoalOnce(goal GoalInfo) (*GoalLink, error) {
 	// Log any country-alias variants that will be tried during matching.
 	// Helps diagnose national-team mismatches (e.g., FotMob "Türkiye" vs
@@ -355,142 +372,31 @@ func (c *Client) searchForGoalOnce(goal GoalInfo) (*GoalLink, error) {
 			goal.AwayTeam, aliases, goal.MatchID, goal.Minute))
 	}
 
-	// Strategy 1: Both teams + minute (most specific, try first)
-	query1 := fmt.Sprintf("%s %s %d'", goal.HomeTeam, goal.AwayTeam, goal.Minute)
-	c.DebugLog(fmt.Sprintf("Reddit search query: '%s' for goal %d:%d (%s vs %s)",
-		query1, goal.MatchID, goal.Minute, goal.HomeTeam, goal.AwayTeam))
-	results1, err := c.fetcher.Search(query1, 15, goal.MatchTime, "relevance")
+	query := buildGoalQuery(goal)
+	c.DebugLog(fmt.Sprintf("Reddit search query: %q for goal %d:%d (%s %d-%d %s)",
+		query, goal.MatchID, goal.Minute, goal.HomeTeam, goal.HomeScore, goal.AwayScore, goal.AwayTeam))
+
+	results, err := c.fetcher.Search(query, 15, goal.MatchTime, "relevance")
 	if err != nil {
-		c.DebugLog(fmt.Sprintf("Reddit search failed for query '%s': %v", query1, err))
-	} else {
-		c.DebugLog(fmt.Sprintf("Reddit search returned %d results for query '%s'", len(results1), query1))
-		// Debug: log the first few result titles
-		for i, result := range results1 {
-			if i < 3 { // Log first 3 results
-				c.DebugLog(fmt.Sprintf("Result %d: '%s'", i+1, result.Title))
-			}
-		}
+		c.DebugLog(fmt.Sprintf("Reddit search failed for query %q: %v", query, err))
+		return nil, err
 	}
-	if err == nil {
-		// Check if we found a good match with the first strategy
-		match := findBestMatch(results1, goal)
-		c.DebugLog(fmt.Sprintf("findBestMatch result for goal %d:%d (score %d-%d): %v", goal.MatchID, goal.Minute, goal.HomeScore, goal.AwayScore, match != nil))
-		if match != nil {
-			c.DebugLog(fmt.Sprintf("Found goal link for %d:%d: %s (post: %s)", goal.MatchID, goal.Minute, match.URL, match.PostURL))
-			// Found a match, return it immediately to avoid additional API calls
-			return &GoalLink{
-				MatchID:   goal.MatchID,
-				Minute:    goal.Minute,
-				URL:       match.URL,
-				Title:     match.Title,
-				PostURL:   match.PostURL,
-				FetchedAt: time.Now(),
-			}, nil
+	c.DebugLog(fmt.Sprintf("Reddit search returned %d results for query %q", len(results), query))
+	for i, result := range results {
+		if i < 3 {
+			c.DebugLog(fmt.Sprintf("Result %d: %q", i+1, result.Title))
 		}
 	}
 
-	// Strategy 1 didn't find a match, try broader searches
-	// Only try one additional strategy to balance coverage vs rate limiting
-	var allResults []SearchResult
-	if err == nil {
-		allResults = append(allResults, results1...)
-	}
-
-	// Strategy 2: Try with just the scoring team + minute
-	// Determine which team scored
-	scoringTeam := goal.AwayTeam
-	if goal.IsHomeTeam {
-		scoringTeam = goal.HomeTeam
-	}
-	query2 := fmt.Sprintf("%s %d'", scoringTeam, goal.Minute)
-	c.DebugLog(fmt.Sprintf("Reddit search query (strategy 2): '%s' for goal %d:%d", query2, goal.MatchID, goal.Minute))
-	results2, err := c.fetcher.Search(query2, 15, goal.MatchTime, "relevance")
-	if err != nil {
-		c.DebugLog(fmt.Sprintf("Reddit search failed for strategy 2 query '%s': %v", query2, err))
-	} else {
-		c.DebugLog(fmt.Sprintf("Reddit search returned %d results for strategy 2 query '%s'", len(results2), query2))
-		allResults = append(allResults, results2...)
-	}
-
-	// Remove duplicates based on URL
-	seen := make(map[string]bool)
-	uniqueResults := make([]SearchResult, 0, len(allResults))
-	for _, result := range allResults {
-		if !seen[result.URL] {
-			seen[result.URL] = true
-			uniqueResults = append(uniqueResults, result)
-		}
-	}
-
-	// Check if strategies 1+2 found a match before trying strategy 3
-	match := findBestMatch(uniqueResults, goal)
-	if match != nil {
-		c.DebugLog(fmt.Sprintf("Strategy 1+2 match found for goal %d:%d, skipping strategy 3", goal.MatchID, goal.Minute))
-		c.DebugLog(fmt.Sprintf("Found goal link for %d:%d: %s (post: %s)", goal.MatchID, goal.Minute, match.URL, match.PostURL))
-		return &GoalLink{
-			MatchID:   goal.MatchID,
-			Minute:    goal.Minute,
-			URL:       match.URL,
-			Title:     match.Title,
-			PostURL:   match.PostURL,
-			FetchedAt: time.Now(),
-		}, nil
-	}
-
-	// Strategy 3: Try with short/alternative team names + sort by top (upvotes)
-	// Only runs if strategies 1+2 did not find a match
-	homeShort := strings.TrimSpace(goal.HomeTeamShort)
-	awayShort := strings.TrimSpace(goal.AwayTeamShort)
-
-	// Skip if short names are empty or identical to full names (avoids redundant API call)
-	homeShortDifferent := homeShort != "" && !strings.EqualFold(homeShort, goal.HomeTeam)
-	awayShortDifferent := awayShort != "" && !strings.EqualFold(awayShort, goal.AwayTeam)
-
-	if !homeShortDifferent && !awayShortDifferent {
-		c.DebugLog(fmt.Sprintf("Skipping strategy 3 for goal %d:%d: short names empty or identical to full names", goal.MatchID, goal.Minute))
-		return nil, nil // No match found across all strategies
-	}
-
-	// Build query using short names where they differ, falling back to full names
-	homeQuery := goal.HomeTeam
-	if homeShortDifferent {
-		homeQuery = homeShort
-	}
-	awayQuery := goal.AwayTeam
-	if awayShortDifferent {
-		awayQuery = awayShort
-	}
-
-	query3 := fmt.Sprintf("%s %s %d'", homeQuery, awayQuery, goal.Minute)
-	c.DebugLog(fmt.Sprintf("Reddit search query (strategy 3): '%s' for goal %d:%d", query3, goal.MatchID, goal.Minute))
-	results3, err := c.fetcher.Search(query3, 15, goal.MatchTime, "top")
-	if err != nil {
-		c.DebugLog(fmt.Sprintf("Reddit search failed for strategy 3 query '%s': %v", query3, err))
-	} else {
-		c.DebugLog(fmt.Sprintf("Reddit search returned %d results for strategy 3 query '%s'", len(results3), query3))
-		// Debug: log the first few result titles
-		for i, result := range results3 {
-			if i < 3 { // Log first 3 results
-				c.DebugLog(fmt.Sprintf("Strategy 3 result %d: '%s' (score: %d)", i+1, result.Title, result.Score))
-			}
-		}
-		// Combine with all prior results for best match selection
-		for _, result := range results3 {
-			if !seen[result.URL] {
-				seen[result.URL] = true
-				uniqueResults = append(uniqueResults, result)
-			}
-		}
-	}
-
-	// Find the best matching result across all strategies
-	match = findBestMatch(uniqueResults, goal)
-	c.DebugLog(fmt.Sprintf("findBestMatch result (strategy 3) for goal %d:%d: %v", goal.MatchID, goal.Minute, match != nil))
+	match := findBestMatch(results, goal)
+	c.DebugLog(fmt.Sprintf("findBestMatch result for goal %d:%d (score %d-%d): %v",
+		goal.MatchID, goal.Minute, goal.HomeScore, goal.AwayScore, match != nil))
 	if match == nil {
-		return nil, nil // No match found, but not an error
+		return nil, nil
 	}
 
-	c.DebugLog(fmt.Sprintf("Found goal link (strategy 3) for %d:%d: %s (post: %s)", goal.MatchID, goal.Minute, match.URL, match.PostURL))
+	c.DebugLog(fmt.Sprintf("Found goal link for %d:%d: %s (post: %s)",
+		goal.MatchID, goal.Minute, match.URL, match.PostURL))
 	return &GoalLink{
 		MatchID:   goal.MatchID,
 		Minute:    goal.Minute,
@@ -499,6 +405,42 @@ func (c *Client) searchForGoalOnce(goal GoalInfo) (*GoalLink, error) {
 		PostURL:   match.PostURL,
 		FetchedAt: time.Now(),
 	}, nil
+}
+
+// buildGoalQuery returns the single Reddit search query for a goal:
+//
+//	"<home> <homeScore> <awayScore> <away> <scorerLast>"
+//
+// Falls back to "<home> <homeScore> <awayScore> <away>" when the scorer is
+// unknown (own goals, missing data). The scorer token is the last whitespace-
+// separated component of ScorerName with diacritics folded so the query
+// matches anglicized title spellings (e.g., "Núñez" → "Nunez").
+func buildGoalQuery(goal GoalInfo) string {
+	parts := []string{
+		goal.HomeTeam,
+		strconv.Itoa(goal.HomeScore),
+		strconv.Itoa(goal.AwayScore),
+		goal.AwayTeam,
+	}
+	if last := scorerLastToken(goal.ScorerName); last != "" {
+		parts = append(parts, last)
+	}
+	return strings.Join(parts, " ")
+}
+
+// scorerLastToken returns the last whitespace-separated token of name with
+// diacritics folded. Returns "" when name is empty or has no usable token.
+func scorerLastToken(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return ""
+	}
+	folded := foldDiacritics(name)
+	fields := strings.Fields(folded)
+	if len(fields) == 0 {
+		return ""
+	}
+	return fields[len(fields)-1]
 }
 
 // ClearCache clears the goal link cache.

--- a/internal/reddit/client.go
+++ b/internal/reddit/client.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math/rand"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -34,27 +33,15 @@ type Fetcher interface {
 // Uses Reddit's public JSON API with rate limiting.
 type PublicJSONFetcher struct {
 	httpClient  *http.Client
-	userAgent   string
 	rateLimiter *ratelimit.Limiter
 }
 
-// userAgents is a small pool of generic browser-style User-Agent strings.
-// The previous fixed UA "golazo:v1.0.0 (by /u/golazo_app)" matched a pattern
-// that Reddit's edge network was reliably blocking with a 403 + HTML block
-// page. Rotating across browser-shaped UAs blends requests into common
-// traffic. Not a security mechanism — purely a coexistence hint for Reddit's
-// edge heuristics.
-var userAgents = []string{
-	"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15",
-	"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36",
-	"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36",
-	"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36",
-}
-
-// pickUserAgent returns a User-Agent from the rotation pool.
-func pickUserAgent() string {
-	return userAgents[rand.Intn(len(userAgents))]
-}
+// browserUserAgent is sent on every request. The queue's 30s pacing and
+// cooldown subsume the anti-detection role that User-Agent rotation
+// previously played; one fixed browser-shaped UA is enough to coexist with
+// Reddit's edge heuristics without introducing additional sources of
+// nondeterminism in the request signature.
+const browserUserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15"
 
 // NewPublicJSONFetcher creates a new fetcher using public Reddit JSON API.
 func NewPublicJSONFetcher() *PublicJSONFetcher {
@@ -67,10 +54,6 @@ func NewPublicJSONFetcher() *PublicJSONFetcher {
 				IdleConnTimeout:     90 * time.Second,
 			},
 		},
-		// User-Agent is now selected per-request via pickUserAgent(); this
-		// field is kept for backward compatibility with any callers that
-		// inspect it but is no longer the source of truth on the wire.
-		userAgent:   "",
 		rateLimiter: ratelimit.NewFromRate(10), // 10 requests per minute for public API
 	}
 }
@@ -106,15 +89,11 @@ func (f *PublicJSONFetcher) Search(query string, limit int, matchTime time.Time,
 		limit,
 	)
 
-	// Small randomized jitter (200-900ms) before each request to break up
-	// burst patterns that Reddit's edge correlates against bot traffic.
-	time.Sleep(time.Duration(200+rand.Intn(700)) * time.Millisecond)
-
 	req, err := http.NewRequest("GET", searchURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)
 	}
-	req.Header.Set("User-Agent", pickUserAgent())
+	req.Header.Set("User-Agent", browserUserAgent)
 	req.Header.Set("Accept", "application/json, text/plain, */*")
 	req.Header.Set("Accept-Language", "en-US,en;q=0.9")
 
@@ -228,8 +207,12 @@ func (c *Client) GoalLink(goal GoalInfo) (*GoalLink, error) {
 		return link, nil
 	}
 
-	// Search Reddit for the goal
-	link, err := c.searchForGoal(goal)
+	// Search Reddit for the goal via a single-strategy attempt. The queue
+	// (see GoalLinksAsync) is the production path for batched fetches and
+	// owns pacing/cooldown; this singular method is preserved for the
+	// scripts/test_reddit_search.go ad-hoc tool and any direct caller that
+	// wants synchronous single-goal semantics without subscription wiring.
+	link, err := c.searchForGoalOnce(goal)
 	if err != nil {
 		// Don't cache errors - allow retry
 		return nil, err
@@ -244,66 +227,6 @@ func (c *Client) GoalLink(goal GoalInfo) (*GoalLink, error) {
 	}
 
 	return link, nil
-}
-
-// BatchSize is the maximum number of goals to fetch per batch.
-// Reduced to make requests even more spaced out.
-const BatchSize = 3
-
-// BatchDelay is the delay between batches to avoid rate limiting.
-const BatchDelay = 5 * time.Second
-
-// GoalLinks retrieves links for multiple goals, using cache where available.
-// Goals are de-duplicated and batched to avoid rate limiting.
-func (c *Client) GoalLinks(goals []GoalInfo) map[GoalLinkKey]*GoalLink {
-	results := make(map[GoalLinkKey]*GoalLink)
-
-	// De-duplicate goals by key and filter out already-cached goals
-	seen := make(map[GoalLinkKey]bool)
-	var uncachedGoals []GoalInfo
-
-	for _, goal := range goals {
-		key := GoalLinkKey{MatchID: goal.MatchID, Minute: goal.Minute}
-
-		// Skip duplicates
-		if seen[key] {
-			continue
-		}
-		seen[key] = true
-
-		// Check cache first
-		if link := c.cache.Get(key); link != nil {
-			if !IsNotFound(link) {
-				results[key] = link
-			}
-			// Skip - already cached (found or not found)
-			continue
-		}
-
-		uncachedGoals = append(uncachedGoals, goal)
-	}
-
-	// Fetch uncached goals in batches with conservative delays
-	for i := 0; i < len(uncachedGoals); i += BatchSize {
-		// Add delay between batches (not before first batch)
-		if i > 0 {
-			time.Sleep(BatchDelay)
-		}
-
-		// Process batch
-		end := i + BatchSize
-		end = min(end, len(uncachedGoals))
-
-		for _, goal := range uncachedGoals[i:end] {
-			key := GoalLinkKey{MatchID: goal.MatchID, Minute: goal.Minute}
-			link, err := c.GoalLink(goal)
-			if err == nil && link != nil {
-				results[key] = link
-			}
-		}
-	}
-
-	return results
 }
 
 // GoalLinksAsync schedules a fetch for each goal through the per-Client queue
@@ -379,46 +302,6 @@ func (c *Client) goalQueueLazy() *goalQueue {
 		c.queue = newGoalQueue(c.searchForGoalOnce, c.cache, c.debugLogger, 0, 0)
 	})
 	return c.queue
-}
-
-// searchForGoal searches Reddit for a specific goal with conservative retry logic.
-func (c *Client) searchForGoal(goal GoalInfo) (*GoalLink, error) {
-	// Conservative retry logic - Reddit is very aggressive with CAPTCHA detection
-	maxRetries := 2               // Reduced from 3
-	baseDelay := 60 * time.Second // Increased delay between retries
-
-	var lastErr error
-	for attempt := range maxRetries {
-		if attempt > 0 {
-			// Exponential backoff: 30s, 60s, 120s
-			delay := time.Duration(attempt) * baseDelay
-			time.Sleep(delay)
-		}
-
-		result, err := c.searchForGoalOnce(goal)
-		if err == nil {
-			return result, nil
-		}
-
-		lastErr = err
-
-		// Check if this is a CAPTCHA/rate limit error
-		if strings.Contains(err.Error(), "CAPTCHA") ||
-			strings.Contains(err.Error(), "blocking requests") ||
-			strings.Contains(err.Error(), "rate limit") ||
-			strings.Contains(err.Error(), "HTML instead of JSON") {
-			// Don't retry CAPTCHA errors - Reddit is very aggressive, just give up
-			c.DebugLog(fmt.Sprintf("Reddit blocking goal %d:%d: giving up immediately", goal.MatchID, goal.Minute))
-			return nil, err
-		}
-
-		// For other errors, retry on next attempt
-	}
-
-	if lastErr != nil {
-		return nil, lastErr
-	}
-	return nil, nil // No match found after all retries
 }
 
 // searchForGoalOnce performs a single search attempt for a goal.

--- a/internal/reddit/client.go
+++ b/internal/reddit/client.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/0xjuanma/golazo/internal/ratelimit"
@@ -159,6 +160,9 @@ type Client struct {
 	fetcher     Fetcher // Reddit public API fetcher
 	cache       *GoalLinkCache
 	debugLogger DebugLogger // Optional debug logger function
+
+	queueOnce sync.Once
+	queue     *goalQueue
 }
 
 // DebugLog forwards a message to the configured debug logger if one is wired.
@@ -300,6 +304,81 @@ func (c *Client) GoalLinks(goals []GoalInfo) map[GoalLinkKey]*GoalLink {
 	}
 
 	return results
+}
+
+// GoalLinksAsync schedules a fetch for each goal through the per-Client queue
+// and streams results on the returned channel. Cache hits are emitted
+// immediately; uncached goals are enqueued for serial fetching at
+// QueueInterval pacing. The returned channel is closed once every goal in
+// `goals` has produced a result (or been deduplicated against an in-flight
+// peer). Each emitted GoalResult.Link is nil when the goal was not found,
+// was dropped due to an ErrBlocked cooldown, or hit a transient fetch error.
+//
+// Use this in preference to the synchronous GoalLinks: it's what the app's
+// subscription wiring consumes for progressive per-goal UI updates and is
+// the only path that honors the global queue's cooldown semantics.
+func (c *Client) GoalLinksAsync(goals []GoalInfo) <-chan GoalResult {
+	out := make(chan GoalResult, len(goals))
+
+	// First pass: serve cache hits inline (no queue work) and collect the
+	// uncached subset, de-duplicated by key. Same de-dup as the sync path —
+	// keeps the queue contract simple (one fetch per key per batch) while
+	// in-flight de-dup inside the queue handles cross-batch collisions.
+	seen := make(map[GoalLinkKey]bool)
+	var work []GoalInfo
+	for _, g := range goals {
+		key := GoalLinkKey{MatchID: g.MatchID, Minute: g.Minute}
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+
+		if link := c.cache.Get(key); link != nil {
+			if !IsNotFound(link) {
+				out <- GoalResult{Key: key, Link: link}
+			}
+			continue
+		}
+		work = append(work, g)
+	}
+
+	if len(work) == 0 {
+		close(out)
+		return out
+	}
+
+	// Reply channel buffered to len(work) so the queue worker never blocks
+	// when broadcasting results to this batch. The forwarder goroutine below
+	// owns closing `out` once every queued goal has emitted exactly one
+	// GoalResult.
+	replies := make(chan GoalResult, len(work))
+	queue := c.goalQueueLazy()
+	for _, g := range work {
+		queue.Enqueue(g, replies)
+	}
+
+	go func() {
+		defer close(out)
+		for i := 0; i < len(work); i++ {
+			r, ok := <-replies
+			if !ok {
+				return
+			}
+			out <- r
+		}
+	}()
+
+	return out
+}
+
+// goalQueueLazy returns the per-Client queue, constructing it on first use.
+// Keeping construction lazy means the worker goroutine doesn't start until a
+// caller actually opts into the async API.
+func (c *Client) goalQueueLazy() *goalQueue {
+	c.queueOnce.Do(func() {
+		c.queue = newGoalQueue(c.searchForGoalOnce, c.cache, c.debugLogger, 0, 0)
+	})
+	return c.queue
 }
 
 // searchForGoal searches Reddit for a specific goal with conservative retry logic.

--- a/internal/reddit/client.go
+++ b/internal/reddit/client.go
@@ -2,6 +2,7 @@ package reddit
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -12,6 +13,11 @@ import (
 
 	"github.com/0xjuanma/golazo/internal/ratelimit"
 )
+
+// ErrBlocked indicates Reddit's edge returned an HTTP 403 (typically the
+// "blocked by network security" interstitial). Returned by Search so callers
+// can react with errors.Is without sniffing HTML response bodies.
+var ErrBlocked = errors.New("reddit: blocked (HTTP 403)")
 
 // DebugLogger is a function type for debug logging
 type DebugLogger func(message string)
@@ -118,6 +124,9 @@ func (f *PublicJSONFetcher) Search(query string, limit int, matchTime time.Time,
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode == http.StatusForbidden {
+			return nil, fmt.Errorf("%w: body: %s", ErrBlocked, string(body))
+		}
 		return nil, fmt.Errorf("reddit API error: status %d, body: %s", resp.StatusCode, string(body))
 	}
 

--- a/internal/reddit/client_test.go
+++ b/internal/reddit/client_test.go
@@ -116,3 +116,96 @@ func TestSearchReturnsErrBlockedOn403(t *testing.T) {
 		t.Fatalf("Search error %v is not ErrBlocked", err)
 	}
 }
+
+// recordingFetcher captures queries passed to Search so tests can assert on
+// the exact query string searchForGoalOnce constructs (vs. e2e-asserting via
+// httptest, which would re-test url-escaping). Returns whatever results are
+// pre-loaded.
+type recordingFetcher struct {
+	queries []string
+	results []SearchResult
+	err     error
+}
+
+func (r *recordingFetcher) Search(query string, _ int, _ time.Time, _ string) ([]SearchResult, error) {
+	r.queries = append(r.queries, query)
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.results, nil
+}
+
+// TestSearchForGoalOnceQueryFormat pins the single-query format produced by
+// buildGoalQuery / searchForGoalOnce: "<home> <hScore> <aScore> <away>
+// <scorerLast>", with the scorer token omitted when ScorerName is empty.
+// Asserts exactly one fetcher.Search call (strategies 2 and 3 are gone).
+func TestSearchForGoalOnceQueryFormat(t *testing.T) {
+	cases := []struct {
+		name      string
+		goal      GoalInfo
+		wantQuery string
+	}{
+		{
+			name: "scorer present uses last token",
+			goal: GoalInfo{
+				MatchID:    4667791,
+				HomeTeam:   "Iran",
+				AwayTeam:   "New Zealand",
+				HomeScore:  0,
+				AwayScore:  1,
+				ScorerName: "Elijah Just",
+				Minute:     7,
+				IsHomeTeam: false,
+				MatchTime:  time.Now(),
+			},
+			wantQuery: "Iran 0 1 New Zealand Just",
+		},
+		{
+			name: "empty scorer falls back to teams + score",
+			goal: GoalInfo{
+				MatchID:    1,
+				HomeTeam:   "Iran",
+				AwayTeam:   "New Zealand",
+				HomeScore:  1,
+				AwayScore:  1,
+				ScorerName: "",
+				Minute:     50,
+				MatchTime:  time.Now(),
+			},
+			wantQuery: "Iran 1 1 New Zealand",
+		},
+		{
+			name: "scorer with diacritics is folded",
+			goal: GoalInfo{
+				MatchID:    2,
+				HomeTeam:   "Liverpool",
+				AwayTeam:   "Wolves",
+				HomeScore:  2,
+				AwayScore:  0,
+				ScorerName: "Darwin Núñez",
+				Minute:     12,
+				MatchTime:  time.Now(),
+			},
+			wantQuery: "Liverpool 2 0 Wolves Nunez",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fetcher := &recordingFetcher{}
+			client := NewClientWithFetcher(fetcher, &GoalLinkCache{links: make(map[string]GoalLink)})
+
+			_, err := client.searchForGoalOnce(tc.goal)
+			if err != nil {
+				t.Fatalf("searchForGoalOnce returned err: %v", err)
+			}
+			if len(fetcher.queries) != 1 {
+				t.Fatalf("expected exactly 1 fetcher.Search call (single-strategy), got %d: %v",
+					len(fetcher.queries), fetcher.queries)
+			}
+			if fetcher.queries[0] != tc.wantQuery {
+				t.Errorf("query mismatch:\n  got  %q\n  want %q", fetcher.queries[0], tc.wantQuery)
+			}
+		})
+	}
+}

--- a/internal/reddit/client_test.go
+++ b/internal/reddit/client_test.go
@@ -1,6 +1,7 @@
 package reddit
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -90,5 +91,28 @@ func TestPublicJSONFetcherSearchHonorsSortParam(t *testing.T) {
 	}
 	if got := capturedURL.Query().Get("limit"); got != strconv.Itoa(10) {
 		t.Errorf("limit param: got %q, want %q", got, strconv.Itoa(10))
+	}
+}
+
+// TestSearchReturnsErrBlockedOn403 pins the typed-error contract for HTTP 403
+// responses from Reddit's edge. The queue worker introduced in the goal-link
+// rework uses errors.Is(err, ErrBlocked) to enter cooldown; sniffing on
+// response body substrings was the previous (fragile) detection mechanism.
+func TestSearchReturnsErrBlockedOn403(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = io.WriteString(w, `<html>You've been blocked by network security.</html>`)
+	}))
+	defer server.Close()
+
+	fetcher := NewPublicJSONFetcher()
+	fetcher.httpClient.Transport = &rewriteTransport{target: server.URL}
+
+	_, err := fetcher.Search("anything", 5, time.Now(), "relevance")
+	if err == nil {
+		t.Fatal("Search returned nil error for 403 response")
+	}
+	if !errors.Is(err, ErrBlocked) {
+		t.Fatalf("Search error %v is not ErrBlocked", err)
 	}
 }

--- a/internal/reddit/queue.go
+++ b/internal/reddit/queue.go
@@ -1,0 +1,211 @@
+package reddit
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// Defaults for the goal-link queue. Exposed as variables (not constants) so
+// the queue type can override them in tests without test-only flags in
+// production code paths.
+const (
+	// QueueInterval is the minimum gap between successive fetch attempts the
+	// queue worker will perform against Reddit. 30s is conservative; bursts
+	// against Reddit's edge are the failure mode this queue exists to avoid.
+	QueueInterval = 30 * time.Second
+
+	// CooldownPeriod is how long the queue pauses fetching after a single
+	// ErrBlocked response from Reddit. Long enough that an IP-level block
+	// has a chance to clear; short enough that a viewing session usually
+	// recovers within it.
+	CooldownPeriod = 10 * time.Minute
+)
+
+// fetchFunc is the search hook the queue worker calls per goal. Injected so
+// tests can drive the worker without involving httptest. Production wires
+// this to Client.searchForGoalOnce.
+type fetchFunc func(GoalInfo) (*GoalLink, error)
+
+// queuedWork holds a goal scheduled for fetching plus the reply channels of
+// every caller waiting on its result. In-flight de-duplication appends new
+// reply channels to an existing entry instead of enqueuing the goal twice.
+type queuedWork struct {
+	goal    GoalInfo
+	replies []chan<- GoalResult
+}
+
+// goalQueue is a single-worker FIFO queue for Reddit goal-link fetches. It
+// enforces:
+//   - one in-flight request at a time
+//   - a minimum interval (QueueInterval) between fetches
+//   - a global cooldown (CooldownPeriod) entered on the first ErrBlocked
+//   - in-flight de-duplication by GoalLinkKey
+//   - drop-on-block semantics: a fetch that returns ErrBlocked is not cached
+//     and not re-enqueued; callers receive a nil GoalResult.Link and the
+//     queue stops fetching for CooldownPeriod
+//
+// The worker goroutine is started lazily on the first Enqueue call (via
+// sync.Once) so constructing a Client without using the async API does not
+// leak a goroutine.
+type goalQueue struct {
+	keys     chan GoalLinkKey
+	interval time.Duration
+	cooldown time.Duration
+
+	mu            sync.Mutex
+	items         map[GoalLinkKey]*queuedWork
+	cooldownUntil time.Time
+
+	once  sync.Once
+	fetch fetchFunc
+	cache *GoalLinkCache
+	log   DebugLogger
+}
+
+// newGoalQueue constructs a queue. interval and cooldown default to
+// QueueInterval / CooldownPeriod when zero. cache is required (callers rely
+// on the queue persisting successful results); fetch is required.
+func newGoalQueue(fetch fetchFunc, cache *GoalLinkCache, log DebugLogger, interval, cooldown time.Duration) *goalQueue {
+	if interval <= 0 {
+		interval = QueueInterval
+	}
+	if cooldown <= 0 {
+		cooldown = CooldownPeriod
+	}
+	return &goalQueue{
+		keys:     make(chan GoalLinkKey, 1024),
+		interval: interval,
+		cooldown: cooldown,
+		items:    make(map[GoalLinkKey]*queuedWork),
+		fetch:    fetch,
+		cache:    cache,
+		log:      log,
+	}
+}
+
+// Enqueue schedules a fetch for goal. The result is delivered on reply. If a
+// goal with the same (MatchID, Minute) key is already in flight, reply is
+// attached to the existing work and no second fetch occurs.
+//
+// Reply is sent exactly one GoalResult. The caller is responsible for the
+// reply channel having capacity (or a reader). The queue uses a non-blocking
+// send and logs a drop if no slot is available.
+func (q *goalQueue) Enqueue(goal GoalInfo, reply chan<- GoalResult) {
+	q.once.Do(q.start)
+
+	key := GoalLinkKey{MatchID: goal.MatchID, Minute: goal.Minute}
+
+	q.mu.Lock()
+	if existing, ok := q.items[key]; ok {
+		existing.replies = append(existing.replies, reply)
+		q.mu.Unlock()
+		return
+	}
+	q.items[key] = &queuedWork{goal: goal, replies: []chan<- GoalResult{reply}}
+	q.mu.Unlock()
+
+	q.keys <- key
+}
+
+// start runs the single worker. Invoked exactly once per queue via sync.Once
+// from the first Enqueue call.
+func (q *goalQueue) start() {
+	go q.run()
+}
+
+func (q *goalQueue) run() {
+	var lastFetch time.Time
+
+	for key := range q.keys {
+		q.mu.Lock()
+		item := q.items[key]
+		until := q.cooldownUntil
+		q.mu.Unlock()
+
+		if item == nil {
+			continue // defensive: shouldn't happen
+		}
+
+		// Honor cooldown. While inside a cooldown window we still drop the
+		// goal (no fetch, no cache, nil result) per the design contract:
+		// blocked goals are not re-enqueued and not cached, leaving a future
+		// app session free to retry.
+		if d := time.Until(until); d > 0 {
+			q.debugf("queue: dropping goal %d:%d — inside cooldown for %v",
+				key.MatchID, key.Minute, d.Round(time.Second))
+			q.complete(key, nil, false)
+			continue
+		}
+
+		// Pacing: wait out the interval since the last fetch attempt. The
+		// gate applies to every fetch, not only the first, so the queue's
+		// rate-limit guarantee holds even after a cache-hit-skipped item.
+		if !lastFetch.IsZero() {
+			if wait := q.interval - time.Since(lastFetch); wait > 0 {
+				time.Sleep(wait)
+			}
+		}
+
+		link, err := q.fetch(item.goal)
+		lastFetch = time.Now()
+
+		if err != nil && errors.Is(err, ErrBlocked) {
+			q.mu.Lock()
+			q.cooldownUntil = time.Now().Add(q.cooldown)
+			q.mu.Unlock()
+			q.debugf("queue: goal %d:%d hit ErrBlocked — cooldown for %v",
+				key.MatchID, key.Minute, q.cooldown)
+			q.complete(key, nil, false)
+			continue
+		}
+		if err != nil {
+			// Transient (network) error: don't cache, don't re-enqueue. The
+			// next call that produces this goal will retry naturally; logging
+			// keeps the failure visible.
+			q.debugf("queue: goal %d:%d fetch error: %v", key.MatchID, key.Minute, err)
+			q.complete(key, nil, false)
+			continue
+		}
+
+		q.complete(key, link, true)
+	}
+}
+
+// complete sends the result to every waiting reply channel and removes the
+// in-flight entry. When cache is true, persists the outcome (found-link with
+// the 7d TTL, or NotFoundMarker with the 1h TTL).
+func (q *goalQueue) complete(key GoalLinkKey, link *GoalLink, persist bool) {
+	if persist && q.cache != nil {
+		if link != nil {
+			_ = q.cache.Set(*link)
+		} else {
+			_ = q.cache.SetNotFound(key.MatchID, key.Minute)
+		}
+	}
+
+	q.mu.Lock()
+	item := q.items[key]
+	delete(q.items, key)
+	q.mu.Unlock()
+
+	if item == nil {
+		return
+	}
+	result := GoalResult{Key: key, Link: link}
+	for _, r := range item.replies {
+		select {
+		case r <- result:
+		default:
+			q.debugf("queue: dropped result for %d:%d — reply channel full",
+				key.MatchID, key.Minute)
+		}
+	}
+}
+
+func (q *goalQueue) debugf(format string, args ...any) {
+	if q.log != nil {
+		q.log(fmt.Sprintf(format, args...))
+	}
+}

--- a/internal/reddit/queue_test.go
+++ b/internal/reddit/queue_test.go
@@ -1,0 +1,230 @@
+package reddit
+
+import (
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// newTestCache returns a GoalLinkCache backed by a temp file so tests don't
+// touch ~/.golazo. Mirrors the construction path used by NewGoalLinkCache.
+func newTestCache(t *testing.T) *GoalLinkCache {
+	t.Helper()
+	return &GoalLinkCache{
+		links:    make(map[string]GoalLink),
+		filePath: filepath.Join(t.TempDir(), "goal_links.json"),
+	}
+}
+
+// recordingFetchHook is the queue's fetch hook for tests: records timestamps
+// of every call, supports per-call result programming, and is safe under the
+// queue's single-worker contract (no concurrency expected, mutex just guards
+// against accidents).
+type recordingFetchHook struct {
+	mu        sync.Mutex
+	calls     []time.Time
+	results   []*GoalLink
+	errors    []error
+	callCount int32
+}
+
+func (h *recordingFetchHook) fetch(_ GoalInfo) (*GoalLink, error) {
+	idx := atomic.AddInt32(&h.callCount, 1) - 1
+	h.mu.Lock()
+	h.calls = append(h.calls, time.Now())
+	h.mu.Unlock()
+
+	if int(idx) < len(h.errors) && h.errors[idx] != nil {
+		return nil, h.errors[idx]
+	}
+	if int(idx) < len(h.results) {
+		return h.results[idx], nil
+	}
+	return nil, nil
+}
+
+func (h *recordingFetchHook) callTimes() []time.Time {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	out := make([]time.Time, len(h.calls))
+	copy(out, h.calls)
+	return out
+}
+
+// TestQueueIntervalPacing verifies the worker's pacing gate inside run():
+// successive fetches must be separated by at least the configured interval.
+// This is where the QueueInterval guarantee actually lives.
+func TestQueueIntervalPacing(t *testing.T) {
+	const interval = 50 * time.Millisecond
+
+	hook := &recordingFetchHook{
+		results: []*GoalLink{
+			{MatchID: 1, Minute: 1, URL: "https://example.com/1"},
+			{MatchID: 1, Minute: 2, URL: "https://example.com/2"},
+			{MatchID: 1, Minute: 3, URL: "https://example.com/3"},
+		},
+	}
+	q := newGoalQueue(hook.fetch, newTestCache(t), nil, interval, time.Minute)
+
+	replies := make(chan GoalResult, 3)
+	for i := 1; i <= 3; i++ {
+		q.Enqueue(GoalInfo{MatchID: 1, Minute: i}, replies)
+	}
+
+	for i := 0; i < 3; i++ {
+		select {
+		case <-replies:
+		case <-time.After(time.Second):
+			t.Fatalf("timed out waiting for reply %d", i)
+		}
+	}
+
+	times := hook.callTimes()
+	if len(times) != 3 {
+		t.Fatalf("expected 3 fetch calls, got %d", len(times))
+	}
+	for i := 1; i < len(times); i++ {
+		gap := times[i].Sub(times[i-1])
+		if gap+5*time.Millisecond < interval {
+			t.Errorf("call %d -> %d gap %v < interval %v", i-1, i, gap, interval)
+		}
+	}
+}
+
+// TestQueueCooldownOnBlocked verifies that an ErrBlocked response sets the
+// cooldown window such that subsequent goals are dropped (no fetch attempt)
+// while inside the window.
+func TestQueueCooldownOnBlocked(t *testing.T) {
+	hook := &recordingFetchHook{
+		errors: []error{ErrBlocked}, // first (and only) attempt blocked
+	}
+	q := newGoalQueue(hook.fetch, newTestCache(t), nil, time.Millisecond, time.Hour)
+
+	replies := make(chan GoalResult, 2)
+	q.Enqueue(GoalInfo{MatchID: 1, Minute: 1}, replies)
+	q.Enqueue(GoalInfo{MatchID: 1, Minute: 2}, replies)
+
+	got := make([]GoalResult, 0, 2)
+	for i := 0; i < 2; i++ {
+		select {
+		case r := <-replies:
+			got = append(got, r)
+		case <-time.After(time.Second):
+			t.Fatalf("timed out waiting for reply %d", i)
+		}
+	}
+
+	if calls := atomic.LoadInt32(&hook.callCount); calls != 1 {
+		t.Errorf("expected exactly 1 fetch attempt (blocked, then cooldown), got %d", calls)
+	}
+	for _, r := range got {
+		if r.Link != nil {
+			t.Errorf("expected nil Link during cooldown, got %+v for %+v", r.Link, r.Key)
+		}
+	}
+}
+
+// TestQueueDropsOnBlocked verifies that a blocked goal is not cached
+// (neither as a found link nor as a NotFoundMarker) — leaving the next app
+// session free to retry.
+func TestQueueDropsOnBlocked(t *testing.T) {
+	hook := &recordingFetchHook{errors: []error{ErrBlocked}}
+	cache := newTestCache(t)
+	q := newGoalQueue(hook.fetch, cache, nil, time.Millisecond, time.Hour)
+
+	replies := make(chan GoalResult, 1)
+	key := GoalLinkKey{MatchID: 99, Minute: 33}
+	q.Enqueue(GoalInfo{MatchID: 99, Minute: 33}, replies)
+
+	select {
+	case <-replies:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for blocked reply")
+	}
+
+	if link := cache.Get(key); link != nil {
+		t.Errorf("expected no cache entry for blocked goal, got %+v", link)
+	}
+}
+
+// TestQueueDedupesInFlight verifies that enqueuing the same key twice while
+// the first is in flight results in a single fetch, and both reply channels
+// receive the result.
+func TestQueueDedupesInFlight(t *testing.T) {
+	// Block the fetch hook on a signal channel so the second Enqueue lands
+	// while the first is still in flight.
+	gate := make(chan struct{})
+	hook := &slowFetchHook{
+		gate: gate,
+		link: &GoalLink{MatchID: 5, Minute: 10, URL: "https://example.com/dedup"},
+	}
+	q := newGoalQueue(hook.fetch, newTestCache(t), nil, time.Millisecond, time.Hour)
+
+	r1 := make(chan GoalResult, 1)
+	r2 := make(chan GoalResult, 1)
+	g := GoalInfo{MatchID: 5, Minute: 10}
+	q.Enqueue(g, r1)
+	// Tiny pause: ensure the worker has picked up the first item and is
+	// blocked inside the fetch hook before the second Enqueue arrives.
+	time.Sleep(20 * time.Millisecond)
+	q.Enqueue(g, r2)
+
+	close(gate) // release the in-flight fetch
+
+	for _, ch := range []chan GoalResult{r1, r2} {
+		select {
+		case r := <-ch:
+			if r.Link == nil || r.Link.URL != "https://example.com/dedup" {
+				t.Errorf("dedup reply missing expected link, got %+v", r.Link)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("dedup reply channel never received result")
+		}
+	}
+
+	if got := atomic.LoadInt32(&hook.calls); got != 1 {
+		t.Errorf("expected 1 fetch for deduped key, got %d", got)
+	}
+}
+
+type slowFetchHook struct {
+	gate  chan struct{}
+	link  *GoalLink
+	calls int32
+}
+
+func (h *slowFetchHook) fetch(_ GoalInfo) (*GoalLink, error) {
+	atomic.AddInt32(&h.calls, 1)
+	<-h.gate
+	return h.link, nil
+}
+
+// TestQueueLazyStart verifies the worker goroutine is not started until the
+// first Enqueue. Without lazy start, every Client construction would leak an
+// idle goroutine. We assert this behaviorally: the fetch hook must not be
+// invoked by mere construction, only by an actual Enqueue.
+func TestQueueLazyStart(t *testing.T) {
+	hook := &recordingFetchHook{
+		results: []*GoalLink{{MatchID: 1, Minute: 1, URL: "https://example.com/lazy"}},
+	}
+	q := newGoalQueue(hook.fetch, newTestCache(t), nil, time.Millisecond, time.Hour)
+
+	// Give a hypothetical eager worker plenty of scheduler ticks to run.
+	time.Sleep(50 * time.Millisecond)
+	if got := atomic.LoadInt32(&hook.callCount); got != 0 {
+		t.Fatalf("fetch hook called %d times before any Enqueue — worker started eagerly", got)
+	}
+
+	replies := make(chan GoalResult, 1)
+	q.Enqueue(GoalInfo{MatchID: 1, Minute: 1}, replies)
+	select {
+	case <-replies:
+	case <-time.After(time.Second):
+		t.Fatal("worker did not start after first Enqueue")
+	}
+	if got := atomic.LoadInt32(&hook.callCount); got != 1 {
+		t.Errorf("expected 1 fetch after Enqueue, got %d", got)
+	}
+}

--- a/internal/reddit/types.go
+++ b/internal/reddit/types.go
@@ -100,3 +100,12 @@ type GoalInfo struct {
 	IsHomeTeam    bool
 	MatchTime     time.Time
 }
+
+// GoalResult is the per-goal outcome streamed from Client.GoalLinksAsync.
+// Link is nil when the goal was searched but no match was found, or when the
+// fetch was dropped due to a Reddit block (the queue does not cache blocks,
+// so a future call will re-try after the cooldown elapses).
+type GoalResult struct {
+	Key  GoalLinkKey
+	Link *GoalLink
+}


### PR DESCRIPTION
## Summary
Replaces the burst-style goal-link fetching with a single-worker queue paced at 30s/request and a 10min cooldown on Reddit 403s, eliminating the rate-limit cascades that were causing every replay link to fail.

## Updates
- Single-worker reddit queue with global cooldown, in-flight dedup, and drop-on-block semantics
- Higher-signal single query (`<home> <hScore> <aScore> <away> <scorerLast>`) replaces the prior 3-strategy search
- Bubbletea subscription wires per-goal results into the UI progressively instead of all-at-once
- Not-found cache TTL bumped from 5min to 1h to cut intra-session retry churn