### PR TITLE
fix(ui): truncate the main-menu help footer to the terminal width

### DIFF
--- a/internal/ui/menu.go
+++ b/internal/ui/menu.go
@@ -66,7 +66,7 @@ func RenderMainMenu(width, height, selected int, sp spinner.Model, randomSpinner
 		Width(logoWidth).
 		Align(lipgloss.Center).
 		Render(logoContent)
-	help := menuHelpStyle.Render(constants.HelpMainMenu)
+	help := renderMenuHelp(constants.HelpMainMenu, width)
 
 	// Spinner with fixed spacing - always reserve space to prevent movement
 	// Use multiple spinner instances for a longer, more prominent animation
@@ -108,6 +108,20 @@ func RenderMainMenu(width, height, selected int, sp spinner.Model, randomSpinner
 		lipgloss.Center,
 		content,
 	)
+}
+
+// renderMenuHelp renders the main-menu nav-tip/help footer constrained to the
+// available terminal width. When the help string is wider than width it is
+// truncated to a single line (with an ellipsis) via the Truncate helper instead
+// of being wrapped at arbitrary points by lipgloss, which is what produced the
+// broken multi-line footer at narrow widths / large fonts (issue #124).
+func renderMenuHelp(text string, width int) string {
+	// Guard against unset/degenerate widths (e.g. before the first WindowSizeMsg).
+	if width <= 0 {
+		return menuHelpStyle.Render(text)
+	}
+	truncated := Truncate(text, width)
+	return menuHelpStyle.Width(width).MaxWidth(width).Render(truncated)
 }
 
 // RenderGradientText applies a gradient (cyan to red) to multi-line text.

--- a/internal/ui/menu_test.go
+++ b/internal/ui/menu_test.go
@@ -1,0 +1,56 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/0xjuanma/golazo/internal/constants"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// TestRenderMenuHelp_NarrowWidthDoesNotOverflow verifies that the main-menu
+// nav-tip/help footer never renders wider than the available terminal width.
+// At narrow widths (small terminals / large fonts) the long help string must be
+// truncated to a single line rather than wrapped at arbitrary points. See issue
+// #124 (Navigation tips wrap unproperly with different font sizes).
+func TestRenderMenuHelp_NarrowWidthDoesNotOverflow(t *testing.T) {
+	// HelpMainMenu is long enough to overflow a narrow terminal.
+	widths := []int{10, 20, 30, 40}
+	for _, width := range widths {
+		got := renderMenuHelp(constants.HelpMainMenu, width)
+		for _, line := range strings.Split(got, "\n") {
+			if w := lipgloss.Width(line); w > width {
+				t.Errorf("renderMenuHelp(%q, %d): line %q has width %d > %d (overflow)",
+					constants.HelpMainMenu, width, line, w, width)
+			}
+		}
+	}
+}
+
+// TestRenderMenuHelp_LongStringIsTruncatedToOneLine verifies that a help string
+// longer than the width collapses to a single truncated line (with an ellipsis)
+// instead of wrapping into multiple lines.
+func TestRenderMenuHelp_LongStringIsTruncatedToOneLine(t *testing.T) {
+	const width = 20
+	got := renderMenuHelp(constants.HelpMainMenu, width)
+	lines := strings.Split(strings.TrimRight(got, "\n"), "\n")
+	if len(lines) != 1 {
+		t.Errorf("renderMenuHelp at width %d produced %d lines, want 1 (no wrap):\n%q",
+			width, len(lines), got)
+	}
+	if !strings.Contains(got, "...") {
+		t.Errorf("renderMenuHelp at width %d should truncate with ellipsis, got %q", width, got)
+	}
+}
+
+// TestRenderMenuHelp_WideWidthKeepsFullText verifies that when the terminal is
+// wide enough, the full help string is preserved (no truncation).
+func TestRenderMenuHelp_WideWidthKeepsFullText(t *testing.T) {
+	got := renderMenuHelp(constants.HelpMainMenu, 120)
+	if strings.Contains(got, "...") {
+		t.Errorf("renderMenuHelp at wide width should not truncate, got %q", got)
+	}
+	if !strings.Contains(got, "navigate") {
+		t.Errorf("renderMenuHelp at wide width should contain full text, got %q", got)
+	}
+}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -1,18 +1,46 @@
 package ui
 
 import (
+	"strings"
+
 	"github.com/0xjuanma/golazo/internal/constants"
 	"github.com/0xjuanma/golazo/internal/data"
 	"github.com/0xjuanma/golazo/internal/ui/design"
 	"github.com/charmbracelet/lipgloss"
 )
 
-// Truncate truncates text to fit the specified width, appending "..." if truncated.
+// Truncate truncates text to fit the specified display width, appending "..."
+// if truncated. Width is measured in terminal cells (via lipgloss.Width) so that
+// multi-byte glyphs such as the arrow keys in help strings (↑/↓/←/→) are counted
+// by how wide they render, not by their byte length.
 func Truncate(text string, width int) string {
-	if len(text) <= width {
+	if lipgloss.Width(text) <= width {
 		return text
 	}
-	return text[:width-3] + "..."
+	// Not enough room for the ellipsis itself: return what fits, cell by cell.
+	if width <= 3 {
+		return truncateToWidth(text, width)
+	}
+	return truncateToWidth(text, width-3) + "..."
+}
+
+// truncateToWidth returns the longest prefix of text whose display width does
+// not exceed width, counting in terminal cells.
+func truncateToWidth(text string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	var b strings.Builder
+	used := 0
+	for _, r := range text {
+		rw := lipgloss.Width(string(r))
+		if used+rw > width {
+			break
+		}
+		b.WriteRune(r)
+		used += rw
+	}
+	return b.String()
 }
 
 // renderStatusBanner renders a status banner based on the specified type.


### PR DESCRIPTION
## Summary

The main-menu help / nav-tip footer rendered with no width awareness, so lipgloss word-wrapped the long string into a broken multi-line block on narrow terminals / large fonts (#124).

## Fix

`internal/ui/menu.go`: render the help footer through the terminal width and ellipsize to a single line. Also fixes `Truncate` (`internal/ui/ui.go`), which measured byte length and so overcounted the multi-byte arrow glyphs (↑↓←→) — it now measures display cells via `lipgloss.Width`. Added tests asserting the footer never overflows the given width.

Closes #124
