### PR TITLE
feat[wc]: add world cup top scorers dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **World Cup Top Scorers** — Press `s` in the World Cup view to open a ranked top scorers table with live goal tallies for the 2026 World Cup.
 
 ### Changed
 

--- a/internal/api/worldcup.go
+++ b/internal/api/worldcup.go
@@ -34,6 +34,14 @@ type WCKnockoutRound struct {
 	Matchups []WCMatchup
 }
 
+// WCTopScorer represents a player's top scorer entry for the current World Cup.
+type WCTopScorer struct {
+	PlayerName string
+	Team       string
+	Goals      int
+	Assists    int
+}
+
 // WorldCupData contains all World Cup tournament data.
 type WorldCupData struct {
 	Season         string // "2022", "2026"
@@ -43,6 +51,7 @@ type WorldCupData struct {
 	BronzeFinal    *WCMatchup
 	Champion       *Team
 	RunnerUp       *Team
+	TopScorers     []WCTopScorer
 }
 
 // DeriveFinalists extracts champion and runner-up from the final matchup's WinnerID.

--- a/internal/app/messages.go
+++ b/internal/app/messages.go
@@ -118,3 +118,9 @@ type wcUpcomingMsg struct {
 	matches []api.Match
 	err     error
 }
+
+// wcTopScorersMsg contains World Cup top scorer data fetched from FotMob.
+type wcTopScorersMsg struct {
+	scorers []api.WCTopScorer
+	err     error
+}

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -144,6 +144,10 @@ type model struct {
 	wcUpcomingLoading   bool
 	wcUpcomingLastError string
 
+	// World Cup top scorers state
+	wcTopScorers        []api.WCTopScorer
+	wcTopScorersLoading bool
+
 	// Dialog overlay for modal dialogs
 	dialogOverlay *ui.DialogOverlay
 

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -84,6 +84,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case wcUpcomingMsg:
 		return m.handleWCUpcoming(msg)
 
+	case wcTopScorersMsg:
+		return m.handleWCTopScorers(msg)
+
 	default:
 		// Fallback handler for ui.TickMsg type assertion
 		if _, ok := msg.(ui.TickMsg); ok {

--- a/internal/app/wc_commands.go
+++ b/internal/app/wc_commands.go
@@ -123,3 +123,21 @@ func fetchWorldCupUpcoming(parentCtx context.Context, client *fotmob.Client) tea
 		return wcUpcomingMsg{matches: matches}
 	}
 }
+
+// fetchWorldCupTopScorers fetches the current WC top scorers from FotMob and
+// emits a wcTopScorersMsg. Falls back to nil scorers when client is nil.
+func fetchWorldCupTopScorers(parentCtx context.Context, client *fotmob.Client, season string) tea.Cmd {
+	return func() tea.Msg {
+		if client == nil {
+			return wcTopScorersMsg{}
+		}
+		ctx, cancel := context.WithTimeout(parentCtx, 20*time.Second)
+		defer cancel()
+
+		scorers, err := client.WorldCupTopScorers(ctx, season)
+		if err != nil {
+			return wcTopScorersMsg{err: err}
+		}
+		return wcTopScorersMsg{scorers: scorers}
+	}
+}

--- a/internal/app/wc_handlers.go
+++ b/internal/app/wc_handlers.go
@@ -67,6 +67,9 @@ func (m model) handleWCGroupsKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.wcUpcomingLastError = ""
 		return m, tea.Batch(tea.ClearScreen, fetchWorldCupUpcoming(m.loadCtx, m.fotmobClient))
 
+	case "s":
+		return m.openTopScorersDialog()
+
 	default:
 		var cmd tea.Cmd
 		m.wcGroupsList, cmd = m.wcGroupsList.Update(msg)
@@ -95,6 +98,9 @@ func (m model) handleWCBracketKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.wcUpcomingLoading = true
 		m.wcUpcomingLastError = ""
 		return m, tea.Batch(tea.ClearScreen, fetchWorldCupUpcoming(m.loadCtx, m.fotmobClient))
+
+	case "s":
+		return m.openTopScorersDialog()
 	}
 	return m, nil
 }
@@ -144,6 +150,9 @@ func (m model) handleWCGroupGridKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.wcUpcomingLoading = true
 		m.wcUpcomingLastError = ""
 		return m, tea.Batch(tea.ClearScreen, fetchWorldCupUpcoming(m.loadCtx, m.fotmobClient))
+
+	case "s":
+		return m.openTopScorersDialog()
 
 	case "right", "l":
 		if m.wcGridSelectedIdx < n-1 {
@@ -209,12 +218,25 @@ func (m model) handleWCUpcoming(msg wcUpcomingMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-// handleWCTopScorers processes the top scorers response and stores the data.
+// handleWCTopScorers processes the top scorers response, stores the data, and opens the dialog.
 func (m model) handleWCTopScorers(msg wcTopScorersMsg) (tea.Model, tea.Cmd) {
 	m.wcTopScorersLoading = false
 	if msg.err != nil {
 		return m, nil
 	}
 	m.wcTopScorers = msg.scorers
+	if m.dialogOverlay != nil {
+		m.dialogOverlay.OpenDialog(ui.NewTopScorersDialog(msg.scorers))
+	}
 	return m, nil
+}
+
+// openTopScorersDialog opens the top scorers dialog, using cached data when available.
+func (m model) openTopScorersDialog() (tea.Model, tea.Cmd) {
+	if len(m.wcTopScorers) > 0 && m.dialogOverlay != nil {
+		m.dialogOverlay.OpenDialog(ui.NewTopScorersDialog(m.wcTopScorers))
+		return m, nil
+	}
+	m.wcTopScorersLoading = true
+	return m, fetchWorldCupTopScorers(m.loadCtx, m.fotmobClient, m.wcYear)
 }

--- a/internal/app/wc_handlers.go
+++ b/internal/app/wc_handlers.go
@@ -208,3 +208,13 @@ func (m model) handleWCUpcoming(msg wcUpcomingMsg) (tea.Model, tea.Cmd) {
 	m.wcUpcomingLastError = ""
 	return m, nil
 }
+
+// handleWCTopScorers processes the top scorers response and stores the data.
+func (m model) handleWCTopScorers(msg wcTopScorersMsg) (tea.Model, tea.Cmd) {
+	m.wcTopScorersLoading = false
+	if msg.err != nil {
+		return m, nil
+	}
+	m.wcTopScorers = msg.scorers
+	return m, nil
+}

--- a/internal/app/wc_handlers_test.go
+++ b/internal/app/wc_handlers_test.go
@@ -129,6 +129,25 @@ func TestHandleWCTopScorers_StoresScorers(t *testing.T) {
 	}
 }
 
+func TestHandleWCGroupsKeys_SEmitsTopScorersCmd(t *testing.T) {
+	m := newWCTestModel()
+	m.wcSubView = wcSubViewGroups
+
+	_, cmd := m.handleWCGroupsKeys(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
+	if cmd == nil {
+		t.Error("expected non-nil tea.Cmd after pressing s (top scorers fetch)")
+	}
+}
+
+func TestHandleWCGroupGridKeys_SEmitsTopScorersCmd(t *testing.T) {
+	m := newWCTestModel()
+
+	_, cmd := m.handleWCGroupGridKeys(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
+	if cmd == nil {
+		t.Error("expected non-nil tea.Cmd after pressing s (top scorers fetch)")
+	}
+}
+
 func TestHandleWCTopScorers_ErrorClearsLoading(t *testing.T) {
 	m := newWCTestModel()
 	m.wcTopScorersLoading = true

--- a/internal/app/wc_handlers_test.go
+++ b/internal/app/wc_handlers_test.go
@@ -107,6 +107,43 @@ func TestHandleWCUpcoming_StoresError(t *testing.T) {
 	}
 }
 
+func TestHandleWCTopScorers_StoresScorers(t *testing.T) {
+	m := newWCTestModel()
+	m.wcTopScorersLoading = true
+
+	scorers := []api.WCTopScorer{
+		{PlayerName: "Messi", Team: "Argentina", Goals: 6},
+		{PlayerName: "Mbappé", Team: "France", Goals: 4},
+	}
+	next, _ := m.handleWCTopScorers(wcTopScorersMsg{scorers: scorers})
+
+	nm := next.(model)
+	if nm.wcTopScorersLoading {
+		t.Error("wcTopScorersLoading should be false after message handled")
+	}
+	if len(nm.wcTopScorers) != 2 {
+		t.Errorf("wcTopScorers len = %d, want 2", len(nm.wcTopScorers))
+	}
+	if nm.wcTopScorers[0].Goals != 6 {
+		t.Errorf("wcTopScorers[0].Goals = %d, want 6", nm.wcTopScorers[0].Goals)
+	}
+}
+
+func TestHandleWCTopScorers_ErrorClearsLoading(t *testing.T) {
+	m := newWCTestModel()
+	m.wcTopScorersLoading = true
+
+	next, _ := m.handleWCTopScorers(wcTopScorersMsg{err: context.DeadlineExceeded})
+
+	nm := next.(model)
+	if nm.wcTopScorersLoading {
+		t.Error("wcTopScorersLoading should be false after error")
+	}
+	if len(nm.wcTopScorers) != 0 {
+		t.Errorf("wcTopScorers should be empty after error, got %d entries", len(nm.wcTopScorers))
+	}
+}
+
 // ── bracket unavailable feedback (Phase 2) ───────────────────────────────────
 
 // TestHandleWCGroupsKeys_BWithNoKnockoutRounds verifies that pressing 'b' from

--- a/internal/constants/strings.go
+++ b/internal/constants/strings.go
@@ -48,6 +48,7 @@ const (
 	HelpStandingsDialog    = "Esc: close"
 	HelpFormationsDialog   = "Tab/←/→: switch team  Esc: close"
 	HelpStatisticsDialog   = "↑/↓: navigate  Esc: close"
+	HelpTopScorersDialog   = "↑/↓: navigate  Esc: close"
 
 	// Edge case user-facing hints
 	ErrorNoStatistics = "No statistics available yet"

--- a/internal/fotmob/worldcup.go
+++ b/internal/fotmob/worldcup.go
@@ -31,6 +31,25 @@ type wcPageResponse struct {
 	Overview struct {
 		SelectedSeason string `json:"selectedSeason"`
 	} `json:"overview"`
+	Stats struct {
+		Players []struct {
+			Header      string `json:"header"`
+			Name        string `json:"name"`
+			FetchAllURL string `json:"fetchAllUrl"`
+		} `json:"players"`
+	} `json:"stats"`
+}
+
+// wcStatList is the shape of the data.fotmob.com stats JSON endpoint.
+type wcStatList struct {
+	TopLists []struct {
+		StatList []struct {
+			ParticipantName string  `json:"ParticipantName"`
+			TeamName        string  `json:"TeamName"`
+			StatValue       float64 `json:"StatValue"`
+			Rank            int     `json:"Rank"`
+		} `json:"StatList"`
+	} `json:"TopLists"`
 }
 
 type wcPlayoff struct {
@@ -318,3 +337,76 @@ func wcGroupLetter(name string) string {
 }
 
 func intPtr(v int) *int { i := v; return &i }
+
+// WorldCupTopScorers fetches the top scorers for the current World Cup season.
+// It reuses the same page fetch as WorldCupData to obtain the stats URL, then
+// makes one additional call to data.fotmob.com for the full ranked list.
+func (c *Client) WorldCupTopScorers(ctx context.Context, season string) ([]api.WCTopScorer, error) {
+	c.rateLimiter.Wait()
+
+	pageProps, err := fetchWorldCupPage(ctx, c.httpClient, season)
+	if err != nil {
+		return nil, fmt.Errorf("fetch world cup page for scorers: %w", err)
+	}
+
+	var resp wcPageResponse
+	if err := json.Unmarshal(pageProps, &resp); err != nil {
+		return nil, fmt.Errorf("parse world cup page props for scorers: %w", err)
+	}
+
+	// Find the "Top scorer" / "goals" stat entry to get the full-list URL.
+	fetchURL := ""
+	for _, p := range resp.Stats.Players {
+		if p.Name == "goals" {
+			fetchURL = p.FetchAllURL
+			break
+		}
+	}
+	if fetchURL == "" {
+		return nil, fmt.Errorf("top scorer stat URL not found in world cup page")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", fetchURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create top scorers request: %w", err)
+	}
+	req.Header.Set("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36")
+	req.Header.Set("Referer", "https://www.fotmob.com/")
+
+	statResp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch top scorers data: %w", err)
+	}
+	defer func() { _ = statResp.Body.Close() }()
+
+	if statResp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("top scorers endpoint returned status %d", statResp.StatusCode)
+	}
+
+	var statList wcStatList
+	if err := json.NewDecoder(statResp.Body).Decode(&statList); err != nil {
+		return nil, fmt.Errorf("decode top scorers response: %w", err)
+	}
+
+	if len(statList.TopLists) == 0 {
+		return nil, nil
+	}
+	return parseWCTopScorers(statList), nil
+}
+
+// parseWCTopScorers converts a raw stat list response into API top scorer entries.
+func parseWCTopScorers(statList wcStatList) []api.WCTopScorer {
+	if len(statList.TopLists) == 0 {
+		return nil
+	}
+	entries := statList.TopLists[0].StatList
+	scorers := make([]api.WCTopScorer, 0, len(entries))
+	for _, e := range entries {
+		scorers = append(scorers, api.WCTopScorer{
+			PlayerName: e.ParticipantName,
+			Team:       e.TeamName,
+			Goals:      int(e.StatValue),
+		})
+	}
+	return scorers
+}

--- a/internal/fotmob/worldcup_test.go
+++ b/internal/fotmob/worldcup_test.go
@@ -264,6 +264,52 @@ func TestConvertMatchup_NotYetPlayed(t *testing.T) {
 	}
 }
 
+func TestParseWCTopScorers_Empty(t *testing.T) {
+	got := parseWCTopScorers(wcStatList{})
+	if got != nil {
+		t.Errorf("expected nil for empty stat list, got %v", got)
+	}
+}
+
+func TestParseWCTopScorers_RoundTrip(t *testing.T) {
+	fixture := wcStatList{
+		TopLists: []struct {
+			StatList []struct {
+				ParticipantName string  `json:"ParticipantName"`
+				TeamName        string  `json:"TeamName"`
+				StatValue       float64 `json:"StatValue"`
+				Rank            int     `json:"Rank"`
+			} `json:"StatList"`
+		}{
+			{
+				StatList: []struct {
+					ParticipantName string  `json:"ParticipantName"`
+					TeamName        string  `json:"TeamName"`
+					StatValue       float64 `json:"StatValue"`
+					Rank            int     `json:"Rank"`
+				}{
+					{ParticipantName: "Lionel Messi", TeamName: "Argentina", StatValue: 6, Rank: 1},
+					{ParticipantName: "Kylian Mbappé", TeamName: "France", StatValue: 4, Rank: 2},
+				},
+			},
+		},
+	}
+
+	got := parseWCTopScorers(fixture)
+	if len(got) != 2 {
+		t.Fatalf("len(scorers) = %d, want 2", len(got))
+	}
+	if got[0].PlayerName != "Lionel Messi" {
+		t.Errorf("scorers[0].PlayerName = %q, want %q", got[0].PlayerName, "Lionel Messi")
+	}
+	if got[0].Goals != 6 {
+		t.Errorf("scorers[0].Goals = %d, want 6", got[0].Goals)
+	}
+	if got[1].Team != "France" {
+		t.Errorf("scorers[1].Team = %q, want %q", got[1].Team, "France")
+	}
+}
+
 // --- helpers ---
 
 // buildMockWCPageResponse builds a wcPageResponse with n groups, each having 4 teams.

--- a/internal/ui/dialog.go
+++ b/internal/ui/dialog.go
@@ -17,6 +17,7 @@ const (
 	StandingsDialogID  = "standings"
 	FormationsDialogID = "formations"
 	StatisticsDialogID = "statistics"
+	TopScorersDialogID = "top_scorers"
 )
 
 // DialogAction represents an action returned by a dialog after handling a message.

--- a/internal/ui/dialog_topscorers.go
+++ b/internal/ui/dialog_topscorers.go
@@ -1,0 +1,125 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/0xjuanma/golazo/internal/api"
+	"github.com/0xjuanma/golazo/internal/constants"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// TopScorersDialog displays the World Cup top scorers table.
+type TopScorersDialog struct {
+	scorers     []api.WCTopScorer
+	scrollIndex int
+}
+
+// NewTopScorersDialog creates a new top scorers dialog.
+func NewTopScorersDialog(scorers []api.WCTopScorer) *TopScorersDialog {
+	return &TopScorersDialog{
+		scorers:     scorers,
+		scrollIndex: 0,
+	}
+}
+
+// ID returns the dialog identifier.
+func (d *TopScorersDialog) ID() string {
+	return TopScorersDialogID
+}
+
+// Update handles input for the top scorers dialog.
+func (d *TopScorersDialog) Update(msg tea.Msg) (Dialog, DialogAction) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "esc", "s", "q":
+			return d, DialogActionClose{}
+		case "j", "down":
+			d.scrollIndex = scrollDown(d.scrollIndex, len(d.scorers)-1)
+		case "k", "up":
+			d.scrollIndex = scrollUp(d.scrollIndex)
+		}
+	}
+	return d, nil
+}
+
+// View renders the top scorers table.
+func (d *TopScorersDialog) View(width, height int) string {
+	dialogWidth, dialogHeight := DialogSize(width, height, 72, 34)
+	innerWidth := dialogWidth - 6 // account for padding and border
+	content := d.renderTable(innerWidth, dialogHeight-8)
+	return RenderDialogFrameWithHelp("World Cup Top Scorers", content, constants.HelpTopScorersDialog, dialogWidth, dialogHeight)
+}
+
+// Column widths
+const (
+	scorerColRank  = 4
+	scorerColGoals = 6
+)
+
+func (d *TopScorersDialog) renderTable(width, visibleRows int) string {
+	if len(d.scorers) == 0 {
+		return dialogDimStyle.Render("No scorer data available")
+	}
+
+	if visibleRows < 1 {
+		visibleRows = 10
+	}
+
+	teamWidth := 16
+	nameWidth := width - scorerColRank - teamWidth - scorerColGoals - 4
+
+	var lines []string
+
+	// Header
+	header := lipgloss.JoinHorizontal(lipgloss.Top,
+		dialogHeaderStyle.Width(scorerColRank).Align(lipgloss.Right).Render("#"),
+		"  ",
+		dialogHeaderStyle.Width(nameWidth).Align(lipgloss.Left).Render("Player"),
+		dialogHeaderStyle.Width(teamWidth).Align(lipgloss.Left).Render("Team"),
+		dialogHeaderStyle.Width(scorerColGoals).Align(lipgloss.Right).Render("Goals"),
+	)
+	lines = append(lines, header)
+
+	separator := dialogSeparatorStyle.Render(strings.Repeat("─", width))
+	lines = append(lines, separator)
+
+	// Visible window
+	start := d.scrollIndex
+	end := start + visibleRows
+	if end > len(d.scorers) {
+		end = len(d.scorers)
+	}
+
+	for i, s := range d.scorers[start:end] {
+		rank := start + i + 1
+		lines = append(lines, d.renderScorerRow(rank, s, nameWidth, teamWidth, width))
+	}
+
+	return lipgloss.JoinVertical(lipgloss.Left, lines...)
+}
+
+func (d *TopScorersDialog) renderScorerRow(rank int, s api.WCTopScorer, nameWidth, teamWidth, rowWidth int) string {
+	name := truncateString(s.PlayerName, nameWidth-1)
+	team := truncateString(s.Team, teamWidth-1)
+
+	row := lipgloss.JoinHorizontal(lipgloss.Top,
+		dialogAlignRight(scorerColRank, fmt.Sprintf("%d", rank)),
+		"  ",
+		dialogAlignLeft(nameWidth, name),
+		dialogAlignLeft(teamWidth, team),
+		dialogAlignRight(scorerColGoals, fmt.Sprintf("%d", s.Goals)),
+	)
+
+	if rank == 1 {
+		return lipgloss.NewStyle().
+			Background(neonDark).
+			Foreground(neonCyan).
+			Bold(true).
+			Width(rowWidth).
+			Render(row)
+	}
+	return dialogValueStyle.Render(row)
+}

--- a/internal/ui/dialog_topscorers_test.go
+++ b/internal/ui/dialog_topscorers_test.go
@@ -1,0 +1,82 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/0xjuanma/golazo/internal/api"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func stubTopScorers() []api.WCTopScorer {
+	return []api.WCTopScorer{
+		{PlayerName: "Lionel Messi", Team: "Argentina", Goals: 6},
+		{PlayerName: "Kylian Mbappé", Team: "France", Goals: 4},
+		{PlayerName: "Olivier Giroud", Team: "France", Goals: 3},
+	}
+}
+
+func TestTopScorersDialog_ID(t *testing.T) {
+	d := NewTopScorersDialog(nil)
+	if d.ID() != TopScorersDialogID {
+		t.Errorf("ID() = %q, want %q", d.ID(), TopScorersDialogID)
+	}
+}
+
+func TestTopScorersDialog_ViewContainsPlayerName(t *testing.T) {
+	d := NewTopScorersDialog(stubTopScorers())
+	out := d.View(120, 40)
+	if !strings.Contains(out, "Lionel Messi") {
+		t.Error("View() output missing player name 'Lionel Messi'")
+	}
+	if !strings.Contains(out, "Argentina") {
+		t.Error("View() output missing team 'Argentina'")
+	}
+	if !strings.Contains(out, "6") {
+		t.Error("View() output missing goal count '6'")
+	}
+}
+
+func TestTopScorersDialog_ViewContainsTitle(t *testing.T) {
+	d := NewTopScorersDialog(stubTopScorers())
+	out := d.View(120, 40)
+	if !strings.Contains(out, "Top Scorers") {
+		t.Error("View() output missing title 'Top Scorers'")
+	}
+}
+
+func TestTopScorersDialog_CloseOnEsc(t *testing.T) {
+	d := NewTopScorersDialog(stubTopScorers())
+	_, action := d.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if _, ok := action.(DialogActionClose); !ok {
+		t.Errorf("Update(esc) action = %T, want DialogActionClose", action)
+	}
+}
+
+func TestTopScorersDialog_CloseOnS(t *testing.T) {
+	d := NewTopScorersDialog(stubTopScorers())
+	_, action := d.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
+	if _, ok := action.(DialogActionClose); !ok {
+		t.Errorf("Update('s') action = %T, want DialogActionClose", action)
+	}
+}
+
+func TestTopScorersDialog_ScrollDown(t *testing.T) {
+	scorers := make([]api.WCTopScorer, 20)
+	for i := range scorers {
+		scorers[i] = api.WCTopScorer{PlayerName: "Player", Team: "Team", Goals: 20 - i}
+	}
+	d := NewTopScorersDialog(scorers)
+	d.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	if d.scrollIndex != 1 {
+		t.Errorf("scrollIndex = %d after j, want 1", d.scrollIndex)
+	}
+}
+
+func TestTopScorersDialog_EmptyScorers(t *testing.T) {
+	d := NewTopScorersDialog(nil)
+	out := d.View(120, 40)
+	if !strings.Contains(out, "No scorer data") {
+		t.Error("View() with nil scorers should show empty state message")
+	}
+}

--- a/internal/ui/worldcup/bracket.go
+++ b/internal/ui/worldcup/bracket.go
@@ -23,7 +23,7 @@ func RenderBracket(width, height int, wcData *api.WorldCupData, scrollOffset int
 	}
 
 	header := design.RenderHeader(wcData.Name+" — Knockout Bracket", width-2)
-	help := HelpStyle.Width(width).Render("j/k: scroll  u: upcoming  Esc: back to grid  q: quit")
+	help := HelpStyle.Width(width).Render("j/k: scroll  u: upcoming  s: top scorers  Esc: back to grid  q: quit")
 
 	var lines []string
 

--- a/internal/ui/worldcup/groups.go
+++ b/internal/ui/worldcup/groups.go
@@ -97,7 +97,7 @@ func RenderGroupsList(width, height int, wcData *api.WorldCupData, groupsList li
 		phaseHint = lipgloss.NewStyle().Foreground(colorGold).Render("  " + phase)
 	}
 
-	help := HelpStyle.Width(width).Render("↑/↓: navigate  Enter: detail  b: bracket  u: upcoming  /: filter  Esc: back to grid  q: quit")
+	help := HelpStyle.Width(width).Render("↑/↓: navigate  Enter: detail  b: bracket  u: upcoming  s: top scorers  /: filter  Esc: back to grid  q: quit")
 
 	overhead := 4
 	if statusBanner != "" {
@@ -267,7 +267,7 @@ func RenderGroupGrid(width, height int, wcData *api.WorldCupData, selectedGroupI
 	}
 
 	header := design.RenderHeader(wcData.Name+" — Groups Overview", width-2)
-	help := HelpStyle.Width(width).Render("↑/↓/←/→: navigate  Enter: detail  b: bracket  t: table  u: upcoming  Esc: back  q: quit")
+	help := HelpStyle.Width(width).Render("↑/↓/←/→: navigate  Enter: detail  b: bracket  t: table  u: upcoming  s: top scorers  Esc: back  q: quit")
 
 	cols := 2
 	if width > 120 {


### PR DESCRIPTION
## Summary
Adds a top scorers dialog to the World Cup view, showing a live ranked table of goal scorers for the 2026 tournament. Press `s` to open it from the groups, grid, or bracket views.

## Updates
- Added `WCTopScorer` API type and FotMob fetch method for live scorer data
- Wired message, model fields, and command into the Bubble Tea update loop
- Built `TopScorersDialog` component following existing dialog patterns
- Added `s` keybinding across World Cup sub-views with updated help text