### PR TITLE
fix[wc]: show penalty shootout winner and score in bracket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **World Cup Bracket** — Penalty shootout results now correctly show the advancing team; tied matches decided on penalties are marked with `(p)` in the bracket.
 - **World Cup Bracket** — Remove arrow connector between matchup score and winner label
 
 ## [0.30.0] - 2026-06-25

--- a/internal/api/worldcup.go
+++ b/internal/api/worldcup.go
@@ -19,10 +19,12 @@ type WCMatchup struct {
 	AwayTeam    string
 	AwayTeamID  int
 	AwayShort   string
-	HomeScore   *int
-	AwayScore   *int
-	WinnerID    *int
-	IsPenalties bool
+	HomeScore    *int
+	AwayScore    *int
+	HomePenScore *int
+	AwayPenScore *int
+	WinnerID     *int
+	IsPenalties  bool
 	TBDHome     bool
 	TBDAway     bool
 }

--- a/internal/data/worldcup_mock.go
+++ b/internal/data/worldcup_mock.go
@@ -108,11 +108,11 @@ func mockWC2022Bracket() []api.WCKnockoutRound {
 			Matchups: []api.WCMatchup{
 				{HomeTeam: "Netherlands", HomeTeamID: 6708, HomeShort: "NED", AwayTeam: "USA", AwayTeamID: 6713, AwayShort: "USA", HomeScore: intPtr(3), AwayScore: intPtr(1), WinnerID: intPtr(6708)},
 				{HomeTeam: "Argentina", HomeTeamID: 6706, HomeShort: "ARG", AwayTeam: "Australia", AwayTeamID: 6716, AwayShort: "AUS", HomeScore: intPtr(2), AwayScore: intPtr(1), WinnerID: intPtr(6706)},
-				{HomeTeam: "Japan", HomeTeamID: 6715, HomeShort: "JPN", AwayTeam: "Croatia", AwayTeamID: 10155, AwayShort: "CRO", HomeScore: intPtr(1), AwayScore: intPtr(1), WinnerID: intPtr(10155), IsPenalties: true},
+				{HomeTeam: "Japan", HomeTeamID: 6715, HomeShort: "JPN", AwayTeam: "Croatia", AwayTeamID: 10155, AwayShort: "CRO", HomeScore: intPtr(1), AwayScore: intPtr(1), WinnerID: intPtr(10155), IsPenalties: true, HomePenScore: intPtr(1), AwayPenScore: intPtr(3)},
 				{HomeTeam: "Brazil", HomeTeamID: 8256, HomeShort: "BRA", AwayTeam: "South Korea", AwayTeamID: 7804, AwayShort: "KOR", HomeScore: intPtr(4), AwayScore: intPtr(1), WinnerID: intPtr(8256)},
 				{HomeTeam: "England", HomeTeamID: 8491, HomeShort: "ENG", AwayTeam: "Senegal", AwayTeamID: 6395, AwayShort: "SEN", HomeScore: intPtr(3), AwayScore: intPtr(0), WinnerID: intPtr(8491)},
 				{HomeTeam: "France", HomeTeamID: 6723, HomeShort: "FRA", AwayTeam: "Poland", AwayTeamID: 8568, AwayShort: "POL", HomeScore: intPtr(3), AwayScore: intPtr(1), WinnerID: intPtr(6723)},
-				{HomeTeam: "Morocco", HomeTeamID: 6262, HomeShort: "MAR", AwayTeam: "Spain", AwayTeamID: 6720, AwayShort: "ESP", HomeScore: intPtr(0), AwayScore: intPtr(0), WinnerID: intPtr(6262), IsPenalties: true},
+				{HomeTeam: "Morocco", HomeTeamID: 6262, HomeShort: "MAR", AwayTeam: "Spain", AwayTeamID: 6720, AwayShort: "ESP", HomeScore: intPtr(0), AwayScore: intPtr(0), WinnerID: intPtr(6262), IsPenalties: true, HomePenScore: intPtr(3), AwayPenScore: intPtr(0)},
 				{HomeTeam: "Portugal", HomeTeamID: 8361, HomeShort: "POR", AwayTeam: "Switzerland", AwayTeamID: 6717, AwayShort: "SUI", HomeScore: intPtr(6), AwayScore: intPtr(1), WinnerID: intPtr(8361)},
 			},
 		},
@@ -120,8 +120,8 @@ func mockWC2022Bracket() []api.WCKnockoutRound {
 			Stage: "1/4",
 			Label: "Quarterfinals",
 			Matchups: []api.WCMatchup{
-				{HomeTeam: "Netherlands", HomeTeamID: 6708, HomeShort: "NED", AwayTeam: "Argentina", AwayTeamID: 6706, AwayShort: "ARG", HomeScore: intPtr(2), AwayScore: intPtr(2), WinnerID: intPtr(6706), IsPenalties: true},
-				{HomeTeam: "Croatia", HomeTeamID: 10155, HomeShort: "CRO", AwayTeam: "Brazil", AwayTeamID: 8256, AwayShort: "BRA", HomeScore: intPtr(1), AwayScore: intPtr(1), WinnerID: intPtr(10155), IsPenalties: true},
+				{HomeTeam: "Netherlands", HomeTeamID: 6708, HomeShort: "NED", AwayTeam: "Argentina", AwayTeamID: 6706, AwayShort: "ARG", HomeScore: intPtr(2), AwayScore: intPtr(2), WinnerID: intPtr(6706), IsPenalties: true, HomePenScore: intPtr(3), AwayPenScore: intPtr(4)},
+				{HomeTeam: "Croatia", HomeTeamID: 10155, HomeShort: "CRO", AwayTeam: "Brazil", AwayTeamID: 8256, AwayShort: "BRA", HomeScore: intPtr(1), AwayScore: intPtr(1), WinnerID: intPtr(10155), IsPenalties: true, HomePenScore: intPtr(4), AwayPenScore: intPtr(2)},
 				{HomeTeam: "England", HomeTeamID: 8491, HomeShort: "ENG", AwayTeam: "France", AwayTeamID: 6723, AwayShort: "FRA", HomeScore: intPtr(1), AwayScore: intPtr(2), WinnerID: intPtr(6723)},
 				{HomeTeam: "Morocco", HomeTeamID: 6262, HomeShort: "MAR", AwayTeam: "Portugal", AwayTeamID: 8361, AwayShort: "POR", HomeScore: intPtr(1), AwayScore: intPtr(0), WinnerID: intPtr(6262)},
 			},
@@ -138,7 +138,7 @@ func mockWC2022Bracket() []api.WCKnockoutRound {
 			Stage: "final",
 			Label: "Final",
 			Matchups: []api.WCMatchup{
-				{HomeTeam: "Argentina", HomeTeamID: 6706, HomeShort: "ARG", AwayTeam: "France", AwayTeamID: 6723, AwayShort: "FRA", HomeScore: intPtr(3), AwayScore: intPtr(3), WinnerID: intPtr(6706), IsPenalties: true},
+				{HomeTeam: "Argentina", HomeTeamID: 6706, HomeShort: "ARG", AwayTeam: "France", AwayTeamID: 6723, AwayShort: "FRA", HomeScore: intPtr(3), AwayScore: intPtr(3), WinnerID: intPtr(6706), IsPenalties: true, HomePenScore: intPtr(4), AwayPenScore: intPtr(2)},
 			},
 		},
 	}

--- a/internal/fotmob/worldcup.go
+++ b/internal/fotmob/worldcup.go
@@ -69,22 +69,23 @@ type wcMatchupRaw struct {
 	AwayTeam          string `json:"awayTeam"`
 	AwayTeamID        int    `json:"awayTeamId"`
 	AwayTeamShortName string `json:"awayTeamShortName"`
-	WinnerID          int    `json:"winnerId"`
+	Winner            int    `json:"winner"`
 	TBDTeam1          bool   `json:"tbdTeam1"`
 	TBDTeam2          bool   `json:"tbdTeam2"`
 	Matches           []struct {
 		Home struct {
-			Score    int  `json:"score"`
-			PenScore int  `json:"penScore"`
-			Winner   bool `json:"winner"`
+			Score  int  `json:"score"`
+			Winner bool `json:"winner"`
 		} `json:"home"`
 		Away struct {
-			Score    int  `json:"score"`
-			PenScore int  `json:"penScore"`
-			Winner   bool `json:"winner"`
+			Score  int  `json:"score"`
+			Winner bool `json:"winner"`
 		} `json:"away"`
 		Status struct {
 			Finished bool `json:"finished"`
+			Reason   struct {
+				ShortKey string `json:"shortKey"`
+			} `json:"reason"`
 		} `json:"status"`
 	} `json:"matches"`
 }
@@ -317,19 +318,16 @@ func convertMatchup(r wcMatchupRaw) api.WCMatchup {
 			m.WinnerID = intPtr(r.HomeTeamID)
 		} else if match.Away.Winner {
 			m.WinnerID = intPtr(r.AwayTeamID)
-		} else if r.WinnerID != 0 {
-			// fallback: FotMob bracket sometimes omits per-team winner flags
-			// and expresses the overall winner at the matchup level instead
-			m.WinnerID = intPtr(r.WinnerID)
+		} else if r.Winner != 0 {
+			// FotMob bracket uses a matchup-level "winner" field for penalty results
+			// where per-team winner flags are both false
+			m.WinnerID = intPtr(r.Winner)
 		}
 
-		// penalties: tied score at full time with a declared winner
-		if m.WinnerID != nil && *m.HomeScore == *m.AwayScore {
+		// penalties: detected via FotMob's reason shortKey or tied score with a winner
+		if match.Status.Reason.ShortKey == "penalties_short" ||
+			(m.WinnerID != nil && *m.HomeScore == *m.AwayScore) {
 			m.IsPenalties = true
-			if match.Home.PenScore != 0 || match.Away.PenScore != 0 {
-				m.HomePenScore = intPtr(match.Home.PenScore)
-				m.AwayPenScore = intPtr(match.Away.PenScore)
-			}
 		}
 	}
 

--- a/internal/fotmob/worldcup.go
+++ b/internal/fotmob/worldcup.go
@@ -69,16 +69,19 @@ type wcMatchupRaw struct {
 	AwayTeam          string `json:"awayTeam"`
 	AwayTeamID        int    `json:"awayTeamId"`
 	AwayTeamShortName string `json:"awayTeamShortName"`
+	WinnerID          int    `json:"winnerId"`
 	TBDTeam1          bool   `json:"tbdTeam1"`
 	TBDTeam2          bool   `json:"tbdTeam2"`
 	Matches           []struct {
 		Home struct {
-			Score  int  `json:"score"`
-			Winner bool `json:"winner"`
+			Score    int  `json:"score"`
+			PenScore int  `json:"penScore"`
+			Winner   bool `json:"winner"`
 		} `json:"home"`
 		Away struct {
-			Score  int  `json:"score"`
-			Winner bool `json:"winner"`
+			Score    int  `json:"score"`
+			PenScore int  `json:"penScore"`
+			Winner   bool `json:"winner"`
 		} `json:"away"`
 		Status struct {
 			Finished bool `json:"finished"`
@@ -306,18 +309,27 @@ func convertMatchup(r wcMatchupRaw) api.WCMatchup {
 	}
 
 	if len(r.Matches) > 0 && r.Matches[0].Status.Finished {
-		m.HomeScore = intPtr(r.Matches[0].Home.Score)
-		m.AwayScore = intPtr(r.Matches[0].Away.Score)
+		match := r.Matches[0]
+		m.HomeScore = intPtr(match.Home.Score)
+		m.AwayScore = intPtr(match.Away.Score)
 
-		if r.Matches[0].Home.Winner {
+		if match.Home.Winner {
 			m.WinnerID = intPtr(r.HomeTeamID)
-		} else if r.Matches[0].Away.Winner {
+		} else if match.Away.Winner {
 			m.WinnerID = intPtr(r.AwayTeamID)
+		} else if r.WinnerID != 0 {
+			// fallback: FotMob bracket sometimes omits per-team winner flags
+			// and expresses the overall winner at the matchup level instead
+			m.WinnerID = intPtr(r.WinnerID)
 		}
 
-		// Detect penalties: scores level at final whistle but there's a winner
+		// penalties: tied score at full time with a declared winner
 		if m.WinnerID != nil && *m.HomeScore == *m.AwayScore {
 			m.IsPenalties = true
+			if match.Home.PenScore != 0 || match.Away.PenScore != 0 {
+				m.HomePenScore = intPtr(match.Home.PenScore)
+				m.AwayPenScore = intPtr(match.Away.PenScore)
+			}
 		}
 	}
 

--- a/internal/fotmob/worldcup_test.go
+++ b/internal/fotmob/worldcup_test.go
@@ -244,35 +244,36 @@ func TestConvertMatchup_Penalties(t *testing.T) {
 }
 
 func TestConvertMatchup_PenaltyWinnerFallback(t *testing.T) {
-	// Simulates the case where FotMob omits Home.Winner/Away.Winner but provides
-	// a matchup-level WinnerID (e.g. Germany 1-1 Paraguay, Paraguay wins on pens).
+	// Simulates the actual FotMob bracket shape for GER 1-1 PAR (Paraguay wins on pens):
+	// both team-level winner flags are false; the matchup-level "winner" field carries the winner;
+	// status.reason.shortKey = "penalties_short" signals it was a penalty shootout.
 	raw := wcMatchupRaw{
 		HomeTeam:   "Germany",
 		HomeTeamID: 100,
 		AwayTeam:   "Paraguay",
 		AwayTeamID: 200,
-		WinnerID:   200,
+		Winner:     200,
 	}
 	var entry struct {
 		Home struct {
-			Score    int  `json:"score"`
-			PenScore int  `json:"penScore"`
-			Winner   bool `json:"winner"`
+			Score  int  `json:"score"`
+			Winner bool `json:"winner"`
 		} `json:"home"`
 		Away struct {
-			Score    int  `json:"score"`
-			PenScore int  `json:"penScore"`
-			Winner   bool `json:"winner"`
+			Score  int  `json:"score"`
+			Winner bool `json:"winner"`
 		} `json:"away"`
 		Status struct {
 			Finished bool `json:"finished"`
+			Reason   struct {
+				ShortKey string `json:"shortKey"`
+			} `json:"reason"`
 		} `json:"status"`
 	}
 	entry.Home.Score = 1
-	entry.Home.PenScore = 3
 	entry.Away.Score = 1
-	entry.Away.PenScore = 5
 	entry.Status.Finished = true
+	entry.Status.Reason.ShortKey = "penalties_short"
 	raw.Matches = append(raw.Matches, entry)
 	out := convertMatchup(raw)
 
@@ -281,12 +282,6 @@ func TestConvertMatchup_PenaltyWinnerFallback(t *testing.T) {
 	}
 	if !out.IsPenalties {
 		t.Error("IsPenalties = false, want true")
-	}
-	if out.HomePenScore == nil || *out.HomePenScore != 3 {
-		t.Errorf("HomePenScore = %v, want 3", out.HomePenScore)
-	}
-	if out.AwayPenScore == nil || *out.AwayPenScore != 5 {
-		t.Errorf("AwayPenScore = %v, want 5", out.AwayPenScore)
 	}
 }
 
@@ -430,28 +425,32 @@ func makeMockMatchup(homeID, awayID, homeScore, awayScore, winnerID int, _ bool)
 		HomeTeamID: homeID,
 		AwayTeam:   "Away",
 		AwayTeamID: awayID,
+		Winner:     winnerID,
 	}
-	r.Matches = r.Matches[:0:0] // ensure nil-like empty slice then append
 	var entry struct {
 		Home struct {
-			Score    int  `json:"score"`
-			PenScore int  `json:"penScore"`
-			Winner   bool `json:"winner"`
+			Score  int  `json:"score"`
+			Winner bool `json:"winner"`
 		} `json:"home"`
 		Away struct {
-			Score    int  `json:"score"`
-			PenScore int  `json:"penScore"`
-			Winner   bool `json:"winner"`
+			Score  int  `json:"score"`
+			Winner bool `json:"winner"`
 		} `json:"away"`
 		Status struct {
 			Finished bool `json:"finished"`
+			Reason   struct {
+				ShortKey string `json:"shortKey"`
+			} `json:"reason"`
 		} `json:"status"`
 	}
 	entry.Home.Score = homeScore
-	entry.Home.Winner = homeID == winnerID
+	entry.Home.Winner = homeID == winnerID && homeScore != awayScore
 	entry.Away.Score = awayScore
-	entry.Away.Winner = awayID == winnerID
+	entry.Away.Winner = awayID == winnerID && homeScore != awayScore
 	entry.Status.Finished = true
+	if homeScore == awayScore && winnerID != 0 {
+		entry.Status.Reason.ShortKey = "penalties_short"
+	}
 	r.Matches = append(r.Matches, entry)
 	return r
 }

--- a/internal/fotmob/worldcup_test.go
+++ b/internal/fotmob/worldcup_test.go
@@ -243,6 +243,53 @@ func TestConvertMatchup_Penalties(t *testing.T) {
 	}
 }
 
+func TestConvertMatchup_PenaltyWinnerFallback(t *testing.T) {
+	// Simulates the case where FotMob omits Home.Winner/Away.Winner but provides
+	// a matchup-level WinnerID (e.g. Germany 1-1 Paraguay, Paraguay wins on pens).
+	raw := wcMatchupRaw{
+		HomeTeam:   "Germany",
+		HomeTeamID: 100,
+		AwayTeam:   "Paraguay",
+		AwayTeamID: 200,
+		WinnerID:   200,
+	}
+	var entry struct {
+		Home struct {
+			Score    int  `json:"score"`
+			PenScore int  `json:"penScore"`
+			Winner   bool `json:"winner"`
+		} `json:"home"`
+		Away struct {
+			Score    int  `json:"score"`
+			PenScore int  `json:"penScore"`
+			Winner   bool `json:"winner"`
+		} `json:"away"`
+		Status struct {
+			Finished bool `json:"finished"`
+		} `json:"status"`
+	}
+	entry.Home.Score = 1
+	entry.Home.PenScore = 3
+	entry.Away.Score = 1
+	entry.Away.PenScore = 5
+	entry.Status.Finished = true
+	raw.Matches = append(raw.Matches, entry)
+	out := convertMatchup(raw)
+
+	if out.WinnerID == nil || *out.WinnerID != 200 {
+		t.Errorf("WinnerID = %v, want 200", out.WinnerID)
+	}
+	if !out.IsPenalties {
+		t.Error("IsPenalties = false, want true")
+	}
+	if out.HomePenScore == nil || *out.HomePenScore != 3 {
+		t.Errorf("HomePenScore = %v, want 3", out.HomePenScore)
+	}
+	if out.AwayPenScore == nil || *out.AwayPenScore != 5 {
+		t.Errorf("AwayPenScore = %v, want 5", out.AwayPenScore)
+	}
+}
+
 func TestConvertMatchup_NotYetPlayed(t *testing.T) {
 	raw := wcMatchupRaw{
 		HomeTeam:   "Team A",
@@ -378,29 +425,33 @@ func buildMockWCPageResponse(numGroups int) wcPageResponse {
 
 // makeMockMatchup creates a finished wcMatchupRaw.
 func makeMockMatchup(homeID, awayID, homeScore, awayScore, winnerID int, _ bool) wcMatchupRaw {
-	return wcMatchupRaw{
+	r := wcMatchupRaw{
 		HomeTeam:   "Home",
 		HomeTeamID: homeID,
 		AwayTeam:   "Away",
 		AwayTeamID: awayID,
-		Matches: []struct {
-			Home struct {
-				Score  int  `json:"score"`
-				Winner bool `json:"winner"`
-			} `json:"home"`
-			Away struct {
-				Score  int  `json:"score"`
-				Winner bool `json:"winner"`
-			} `json:"away"`
-			Status struct {
-				Finished bool `json:"finished"`
-			} `json:"status"`
-		}{
-			{
-				Home:   struct { Score int `json:"score"`; Winner bool `json:"winner"` }{Score: homeScore, Winner: homeID == winnerID},
-				Away:   struct { Score int `json:"score"`; Winner bool `json:"winner"` }{Score: awayScore, Winner: awayID == winnerID},
-				Status: struct { Finished bool `json:"finished"` }{Finished: true},
-			},
-		},
 	}
+	r.Matches = r.Matches[:0:0] // ensure nil-like empty slice then append
+	var entry struct {
+		Home struct {
+			Score    int  `json:"score"`
+			PenScore int  `json:"penScore"`
+			Winner   bool `json:"winner"`
+		} `json:"home"`
+		Away struct {
+			Score    int  `json:"score"`
+			PenScore int  `json:"penScore"`
+			Winner   bool `json:"winner"`
+		} `json:"away"`
+		Status struct {
+			Finished bool `json:"finished"`
+		} `json:"status"`
+	}
+	entry.Home.Score = homeScore
+	entry.Home.Winner = homeID == winnerID
+	entry.Away.Score = awayScore
+	entry.Away.Winner = awayID == winnerID
+	entry.Status.Finished = true
+	r.Matches = append(r.Matches, entry)
+	return r
 }

--- a/internal/ui/worldcup/bracket.go
+++ b/internal/ui/worldcup/bracket.go
@@ -198,8 +198,8 @@ func renderBracketLineRaw(mu api.WCMatchup, showArrow bool) string {
 		winnerLabel = MatchupTeamLabel(mu.AwayShort, mu.AwayTeam, mu.TBDAway)
 	}
 	penStr := ""
-	if mu.IsPenalties {
-		penStr = " " + PenStyle.Render("(p)")
+	if suf := penSuffix(mu); suf != "" {
+		penStr = " " + suf
 	}
 	winner := WinnerStyle.Render(winnerLabel) + penStr
 

--- a/internal/ui/worldcup/bracket_sym.go
+++ b/internal/ui/worldcup/bracket_sym.go
@@ -317,6 +317,18 @@ func sym2Level(qf, sf, fin []api.WCMatchup, wcData *api.WorldCupData) string {
 	return symJoin(ll, rr, 7, centers)
 }
 
+// penSuffix returns the penalty annotation for a matchup score:
+// "(4-2p)" when both pen scores are known, "p" when only the flag is set, "" otherwise.
+func penSuffix(mu api.WCMatchup) string {
+	if mu.HomePenScore != nil && mu.AwayPenScore != nil {
+		return PenStyle.Render(fmt.Sprintf("(%d-%dp)", *mu.HomePenScore, *mu.AwayPenScore))
+	}
+	if mu.IsPenalties {
+		return PenStyle.Render("p")
+	}
+	return ""
+}
+
 // ─── Shared helpers ───────────────────────────────────────────────────────────
 
 // symFinalLabel returns the center line label for the Final matchup.
@@ -329,9 +341,12 @@ func symFinalLabel(fin []api.WCMatchup, wcData *api.WorldCupData) string {
 		home := MatchupTeamLabel(mu.HomeShort, mu.HomeTeam, mu.TBDHome)
 		away := MatchupTeamLabel(mu.AwayShort, mu.AwayTeam, mu.TBDAway)
 		if mu.HomeScore != nil && mu.AwayScore != nil {
-			score := ScoreStyle.Render(fmt.Sprintf("%d–%d", *mu.HomeScore, *mu.AwayScore))
-			if mu.IsPenalties {
-				score += PenStyle.Render("p")
+			score := ScoreStyle.Render(fmt.Sprintf("%d–%d", *mu.HomeScore, *mu.AwayScore)) + penSuffix(mu)
+			if mu.WinnerID != nil {
+				if *mu.WinnerID == mu.HomeTeamID {
+					return WinnerStyle.Render(home) + " " + score + " " + EliminatedStyle.Render(away)
+				}
+				return EliminatedStyle.Render(home) + " " + score + " " + WinnerStyle.Render(away)
 			}
 			return WinnerStyle.Render(home) + " " + score + " " + WinnerStyle.Render(away)
 		}
@@ -460,10 +475,7 @@ func symCompact(mu api.WCMatchup) string {
 	}
 	var score string
 	if mu.HomeScore != nil && mu.AwayScore != nil {
-		score = ScoreStyle.Render(fmt.Sprintf("%d–%d", *mu.HomeScore, *mu.AwayScore))
-		if mu.IsPenalties {
-			score += PenStyle.Render("p")
-		}
+		score = ScoreStyle.Render(fmt.Sprintf("%d–%d", *mu.HomeScore, *mu.AwayScore)) + penSuffix(mu)
 	} else {
 		score = MatchLineStyle.Render("vs")
 	}

--- a/internal/ui/worldcup/bracket_test.go
+++ b/internal/ui/worldcup/bracket_test.go
@@ -79,6 +79,65 @@ func TestRenderBracketRound_ConnectorAlignment(t *testing.T) {
 
 func intPtrLocal(i int) *int { return &i }
 
+func TestPenSuffix(t *testing.T) {
+	cases := []struct {
+		name string
+		mu   api.WCMatchup
+		want string // substring expected in output (empty = expect empty string)
+	}{
+		{"no penalty", api.WCMatchup{}, ""},
+		{"flag only", api.WCMatchup{IsPenalties: true}, "p"},
+		{"with scores", api.WCMatchup{IsPenalties: true, HomePenScore: intPtrLocal(4), AwayPenScore: intPtrLocal(2)}, "(4-2p)"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := penSuffix(c.mu)
+			if c.want == "" {
+				if got != "" {
+					t.Errorf("penSuffix = %q, want empty", got)
+				}
+				return
+			}
+			if !strings.Contains(got, c.want) {
+				t.Errorf("penSuffix = %q, want it to contain %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestSymCompact_PenaltyScore(t *testing.T) {
+	winner := 200
+	mu := api.WCMatchup{
+		HomeTeam: "Germany", HomeTeamID: 100, HomeShort: "GER",
+		AwayTeam: "Paraguay", AwayTeamID: 200, AwayShort: "PAR",
+		HomeScore: intPtrLocal(1), AwayScore: intPtrLocal(1),
+		WinnerID: &winner, IsPenalties: true,
+		HomePenScore: intPtrLocal(3), AwayPenScore: intPtrLocal(5),
+	}
+	got := symCompact(mu)
+	if !strings.Contains(got, "(3-5p)") {
+		t.Errorf("symCompact output %q does not contain (3-5p)", got)
+	}
+	if strings.Contains(got, "p)") && !strings.Contains(got, "(3-5p)") {
+		t.Errorf("symCompact output contains bare 'p)' instead of full penalty score")
+	}
+}
+
+func TestRenderBracketLineRaw_PenaltyScore(t *testing.T) {
+	winner := 200
+	mu := api.WCMatchup{
+		HomeTeam: "Germany", HomeTeamID: 100, HomeShort: "GER",
+		AwayTeam: "Paraguay", AwayTeamID: 200, AwayShort: "PAR",
+		HomeScore: intPtrLocal(1), AwayScore: intPtrLocal(1),
+		WinnerID: &winner, IsPenalties: true,
+		HomePenScore: intPtrLocal(3), AwayPenScore: intPtrLocal(5),
+	}
+	got := renderBracketLineRaw(mu, true)
+	if !strings.Contains(got, "(3-5p)") {
+		t.Errorf("renderBracketLineRaw output %q does not contain (3-5p)", got)
+	}
+}
+
 // TestRenderBracketLineRaw_WidthInvariant locks in the fix for #158: bracket
 // match lines must render at the same total visual width regardless of which
 // flag form (regional-indicator pair, tag-sequence subdivision, or no-flag


### PR DESCRIPTION
## Summary

Fixes the World Cup bracket not displaying the correct winner or penalty indicator for matches decided by penalty shootout (e.g. Germany 1–1 Paraguay, Paraguay advances).

## Updates

- Add `HomePenScore`/`AwayPenScore` fields to `WCMatchup` schema to carry penalty tally when available
- Fix FotMob bracket parser to read the matchup-level `"winner"` field as a fallback when both per-team `winner` flags are `false` (the actual shape FotMob sends for penalty results); also detect penalties via `status.reason.shortKey == "penalties_short"`
- Add `penSuffix` helper in the UI layer; replace bare `"p"` across all three render sites (`symCompact`, `symFinalLabel`, `renderBracketLineRaw`) with compact `"(H-Ap)"` notation when pen scores are known, falling back to `"p"` otherwise
- Update `symFinalLabel` to apply winner/eliminated styling when `WinnerID` is set on a completed final
- Backfill real 2022 penalty shootout scores in mock bracket data for `--mock` mode

**Note**: FotMob's bracket API does not expose the penalty tally, so live matches show `(p)` rather than `(5-3p)`. The winner advancing through the bracket is correctly determined from the `"winner"` field.