### PR TITLE
Adding United Soccer League leagues to North American league list

### DIFF
--- a/docs/SUPPORTED_LEAGUES.md
+++ b/docs/SUPPORTED_LEAGUES.md
@@ -115,7 +115,10 @@ Golazo supports **65+ leagues and competitions**. Customize your selection in Se
 | 🏆 | CONCACAF Nations League |
 | 🇲🇽 | Liga MX |
 | 🇺🇸 | MLS |
+| 🇺🇸 | USL Championship |
+| 🇺🇸 | USL League One |
 | 🇺🇸 | NWSL |
+| 🇺🇸 | USL Gainsbridge Super League |
 
 ## Middle East
 

--- a/internal/data/settings.go
+++ b/internal/data/settings.go
@@ -120,7 +120,10 @@ var AllSupportedLeagues = map[string][]LeagueInfo{
 		{ID: 246, Name: "Serie A", Country: "Ecuador"},
 		// North America
 		{ID: 130, Name: "MLS", Country: "USA"},
+		{ID: 8972, Name: "USL Championship", Country: "USA"},
+		{ID: 9296, Name: "USL League One", Country: "USA"},
 		{ID: 9134, Name: "NWSL", Country: "USA"},
+		{ID: 10699, Name: "USL Gainsbridge Super League", Country: "USA"},
 		{ID: 230, Name: "Liga MX", Country: "Mexico"},
 	},
 	RegionGlobal: {


### PR DESCRIPTION
This will add USL Championship (USA Men's Division 2), USL League One (USA Men's Division 3), and USL Gainsbridge Super League (the other USA Women's Division 1) leagues to the North American league list.