### PR TITLE
feat[data]: migrate config/cache dir logic to cli-toolkit/dirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Config/cache directory resolution now uses `cli-toolkit/dirs` internally instead of hand-rolled logic; no change in behavior or config location.
 
 ### Fixed
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/0xjuanma/golazo
 go 1.25.0
 
 require (
+	github.com/0xjuanma/cli-toolkit v0.1.0
 	github.com/charmbracelet/bubbles v0.21.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 git.sr.ht/~jackmordaunt/go-toast v1.1.2 h1:/yrfI55LRt1M7H1vkaw+NaH1+L1CDxrqDltwm5euVuE=
 git.sr.ht/~jackmordaunt/go-toast v1.1.2/go.mod h1:jA4OqHKTQ4AFBdwrSnwnskUIIS3HYzlJSgdzCKqfavo=
+github.com/0xjuanma/cli-toolkit v0.1.0 h1:MvRSVUBhixqOkYLwg43xzW26jJuX15QUm2Rj2vMzszQ=
+github.com/0xjuanma/cli-toolkit v0.1.0/go.mod h1:lHLFRUaicFHF3gwxgW6AYqBvvWvm7AFBP+ezoWaYJjU=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=

--- a/internal/data/storage.go
+++ b/internal/data/storage.go
@@ -8,44 +8,19 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"time"
+
+	"github.com/0xjuanma/cli-toolkit/dirs"
 )
 
-const (
-	configDir = ".golazo"
-)
+var appDirs = dirs.New("golazo")
 
 // ConfigDir returns the path to the golazo config directory.
 // On Linux, follows XDG Base Directory spec (~/.config/golazo).
 // On other systems (macOS, Windows), uses ~/.golazo.
 func ConfigDir() (string, error) {
-	var configPath string
-
-	if runtime.GOOS == "linux" {
-		if xdgConfig := os.Getenv("XDG_CONFIG_HOME"); xdgConfig != "" {
-			configPath = filepath.Join(xdgConfig, "golazo")
-		} else {
-			homeDir, err := os.UserHomeDir()
-			if err != nil {
-				return "", fmt.Errorf("get home directory: %w", err)
-			}
-			configPath = filepath.Join(homeDir, ".config", "golazo")
-		}
-	} else {
-		homeDir, err := os.UserHomeDir()
-		if err != nil {
-			return "", fmt.Errorf("get home directory: %w", err)
-		}
-		configPath = filepath.Join(homeDir, configDir)
-	}
-
-	if err := os.MkdirAll(configPath, 0755); err != nil {
-		return "", fmt.Errorf("create config directory: %w", err)
-	}
-
-	return configPath, nil
+	return appDirs.ConfigDir()
 }
 
 // DebugLogPath returns the user-facing path to the debug log file, with the
@@ -53,16 +28,7 @@ func ConfigDir() (string, error) {
 // and mirrors the location used by ConfigDir, but performs no filesystem I/O
 // and does not create any directories. Safe to call from init() / flag help.
 func DebugLogPath() string {
-	const logFile = "golazo_debug.log"
-
-	if runtime.GOOS == "linux" {
-		if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
-			return filepath.Join(xdg, "golazo", logFile)
-		}
-		return filepath.Join("~", ".config", "golazo", logFile)
-	}
-
-	return filepath.Join("~", configDir, logFile)
+	return appDirs.ConfigFileDisplay("golazo_debug.log")
 }
 
 // CacheDir returns the path to the golazo cache directory.
@@ -71,17 +37,7 @@ func DebugLogPath() string {
 //   - macOS: ~/Library/Caches/golazo
 //   - Windows: %LocalAppData%/golazo
 func CacheDir() (string, error) {
-	userCache, err := os.UserCacheDir()
-	if err != nil {
-		return "", fmt.Errorf("get user cache directory: %w", err)
-	}
-
-	cachePath := filepath.Join(userCache, "golazo")
-	if err := os.MkdirAll(cachePath, 0755); err != nil {
-		return "", fmt.Errorf("create cache directory: %w", err)
-	}
-
-	return cachePath, nil
+	return appDirs.CacheDir()
 }
 
 // MockDataPath returns the path to the mock data file.


### PR DESCRIPTION
## Summary
- Replace golazo's hand-rolled `ConfigDir`/`DebugLogPath`/`CacheDir` logic in `internal/data/storage.go` with thin wrappers over https://github.com/0xjuanma/cli-toolkit `/dirs` (already tagged v0.1.0 and used in a sibling project).
- Pure internal refactor — `dirs` was extracted verbatim from this exact code in an earlier session, so behavior and config location are unchanged on all platforms.

## Updates
- `internal/data/storage.go`: `ConfigDir()`, `DebugLogPath()`, `CacheDir()` now delegate to a package-level `var appDirs = dirs.New("golazo")`; removed the hand-rolled XDG/GOOS branching, the `.golazo` const, and the now-unused `runtime` import.
- Zero call-site changes — all 6+ external callers (`cmd/root.go`, `internal/ui/ui.go`, `internal/notify/notify.go`, `internal/app/model.go`, `internal/fotmob/empty_cache.go`, `internal/reddit/cache.go`) keep calling the same package-level functions with unchanged signatures.
- Verified via `go build`/`go vet`/`go mod verify`/`go test` across all application packages (excluded a pre-existing, unrelated build break in `scripts/`, confirmed via `git stash` to predate this change). `TestDebugLogPath`'s exact-string assertions pass unmodified.