### PR TITLE
feat[reddit]: harden goal-link retrieval against Reddit blocking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Config/cache directory resolution now uses `cli-toolkit/dirs` internally instead of hand-rolled logic; no change in behavior or config location.
+- **Reddit goal-link retrieval** — cooldown after a Reddit block now persists across app restarts and grows exponentially (with jitter) on repeated blocks, instead of resetting on restart and staying fixed at 10 minutes.
+- **Reddit goal-link retrieval** — goal searches get one retry with a relaxed query (scorer name dropped) when the first attempt finds no match.
 
 ### Fixed
 

--- a/internal/reddit/client.go
+++ b/internal/reddit/client.go
@@ -299,7 +299,12 @@ func (c *Client) GoalLinksAsync(goals []GoalInfo) <-chan GoalResult {
 // caller actually opts into the async API.
 func (c *Client) goalQueueLazy() *goalQueue {
 	c.queueOnce.Do(func() {
-		c.queue = newGoalQueue(c.searchForGoalOnce, c.cache, c.debugLogger, 0, 0)
+		store, err := newQueueStateStore()
+		if err != nil {
+			c.DebugLog(fmt.Sprintf("failed to init queue state store: %v", err))
+			store = nil
+		}
+		c.queue = newGoalQueue(c.searchForGoalOnce, c.cache, c.debugLogger, 0, 0, store)
 	})
 	return c.queue
 }

--- a/internal/reddit/client.go
+++ b/internal/reddit/client.go
@@ -358,6 +358,11 @@ func (c *Client) searchForGoalOnce(goal GoalInfo) (*GoalLink, error) {
 	match := findBestMatch(results, goal)
 	c.DebugLog(fmt.Sprintf("findBestMatch result for goal %d:%d (score %d-%d): %v",
 		goal.MatchID, goal.Minute, goal.HomeScore, goal.AwayScore, match != nil))
+
+	if match == nil && goal.ScorerName != "" {
+		match = c.retrySearchForGoal(goal)
+	}
+
 	if match == nil {
 		return nil, nil
 	}
@@ -372,6 +377,35 @@ func (c *Client) searchForGoalOnce(goal GoalInfo) (*GoalLink, error) {
 		PostURL:   match.PostURL,
 		FetchedAt: time.Now(),
 	}, nil
+}
+
+// retrySearchForGoal re-searches once with the scorer token dropped from the
+// query, for goals whose first (full) query found no match. Only called when
+// goal.ScorerName is non-empty — a goal with no scorer name already searched
+// with this exact relaxed shape (buildGoalQuery omits the scorer token when
+// ScorerName is empty), so retrying it would be a wasted duplicate request.
+//
+// findBestMatch is re-run against the original goal (ScorerName intact, not
+// the relaxed one), so a scorer name that still appears incidentally in a
+// relaxed-query result's title earns its normal matcher bonus.
+func (c *Client) retrySearchForGoal(goal GoalInfo) *SearchResult {
+	relaxed := goal
+	relaxed.ScorerName = ""
+	query := buildGoalQuery(relaxed)
+	c.DebugLog(fmt.Sprintf("Reddit relaxed retry query: %q for goal %d:%d (no match on first attempt)",
+		query, goal.MatchID, goal.Minute))
+
+	results, err := c.fetcher.Search(query, 15, goal.MatchTime, "relevance")
+	if err != nil {
+		c.DebugLog(fmt.Sprintf("Reddit relaxed retry failed for query %q: %v", query, err))
+		return nil
+	}
+	c.DebugLog(fmt.Sprintf("Reddit relaxed retry returned %d results for query %q", len(results), query))
+
+	match := findBestMatch(results, goal)
+	c.DebugLog(fmt.Sprintf("findBestMatch result for relaxed retry on goal %d:%d: %v",
+		goal.MatchID, goal.Minute, match != nil))
+	return match
 }
 
 // buildGoalQuery returns the single Reddit search query for a goal:

--- a/internal/reddit/client_test.go
+++ b/internal/reddit/client_test.go
@@ -119,31 +119,41 @@ func TestSearchReturnsErrBlockedOn403(t *testing.T) {
 
 // recordingFetcher captures queries passed to Search so tests can assert on
 // the exact query string searchForGoalOnce constructs (vs. e2e-asserting via
-// httptest, which would re-test url-escaping). Returns whatever results are
-// pre-loaded.
+// httptest, which would re-test url-escaping). resultSets is indexed by call
+// count — call N returns resultSets[N], or no results if N is out of range —
+// so tests can program a first (full-query) call that finds nothing and a
+// second (relaxed-retry) call that does.
 type recordingFetcher struct {
-	queries []string
-	results []SearchResult
-	err     error
+	queries    []string
+	resultSets [][]SearchResult
+	err        error
 }
 
 func (r *recordingFetcher) Search(query string, _ int, _ time.Time, _ string) ([]SearchResult, error) {
+	idx := len(r.queries)
 	r.queries = append(r.queries, query)
 	if r.err != nil {
 		return nil, r.err
 	}
-	return r.results, nil
+	if idx < len(r.resultSets) {
+		return r.resultSets[idx], nil
+	}
+	return nil, nil
 }
 
-// TestSearchForGoalOnceQueryFormat pins the single-query format produced by
+// TestSearchForGoalOnceQueryFormat pins the query format produced by
 // buildGoalQuery / searchForGoalOnce: "<home> <hScore> <aScore> <away>
 // <scorerLast>", with the scorer token omitted when ScorerName is empty.
-// Asserts exactly one fetcher.Search call (strategies 2 and 3 are gone).
+// Each scorer-present case programs a matching first-call result so it
+// resolves without triggering the relaxed retry (that path is covered
+// separately by TestSearchForGoalOnceFallbackOnNoMatch) — asserts exactly
+// one fetcher.Search call.
 func TestSearchForGoalOnceQueryFormat(t *testing.T) {
 	cases := []struct {
-		name      string
-		goal      GoalInfo
-		wantQuery string
+		name        string
+		goal        GoalInfo
+		wantQuery   string
+		firstResult []SearchResult // nil is fine when no retry is possible anyway (empty ScorerName)
 	}{
 		{
 			name: "scorer present uses last token",
@@ -159,6 +169,12 @@ func TestSearchForGoalOnceQueryFormat(t *testing.T) {
 				MatchTime:  time.Now(),
 			},
 			wantQuery: "Iran 0 1 New Zealand Just",
+			firstResult: []SearchResult{{
+				Title:     "Iran 0 - [1] New Zealand - E. Just 7'",
+				URL:       "https://example.com/iran-nz",
+				PostURL:   "https://www.reddit.com/r/soccer/comments/iran-nz",
+				CreatedAt: time.Now(),
+			}},
 		},
 		{
 			name: "empty scorer falls back to teams + score",
@@ -187,12 +203,18 @@ func TestSearchForGoalOnceQueryFormat(t *testing.T) {
 				MatchTime:  time.Now(),
 			},
 			wantQuery: "Liverpool 2 0 Wolves Nunez",
+			firstResult: []SearchResult{{
+				Title:     "Liverpool [2] - 0 Wolves - Darwin Nunez 12'",
+				URL:       "https://example.com/liv-wolves",
+				PostURL:   "https://www.reddit.com/r/soccer/comments/liv-wolves",
+				CreatedAt: time.Now(),
+			}},
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			fetcher := &recordingFetcher{}
+			fetcher := &recordingFetcher{resultSets: [][]SearchResult{tc.firstResult}}
 			client := NewClientWithFetcher(fetcher, &GoalLinkCache{links: make(map[string]GoalLink)})
 
 			_, err := client.searchForGoalOnce(tc.goal)
@@ -200,12 +222,91 @@ func TestSearchForGoalOnceQueryFormat(t *testing.T) {
 				t.Fatalf("searchForGoalOnce returned err: %v", err)
 			}
 			if len(fetcher.queries) != 1 {
-				t.Fatalf("expected exactly 1 fetcher.Search call (single-strategy), got %d: %v",
+				t.Fatalf("expected exactly 1 fetcher.Search call (matched on first attempt), got %d: %v",
 					len(fetcher.queries), fetcher.queries)
 			}
 			if fetcher.queries[0] != tc.wantQuery {
 				t.Errorf("query mismatch:\n  got  %q\n  want %q", fetcher.queries[0], tc.wantQuery)
 			}
 		})
+	}
+}
+
+// TestSearchForGoalOnceFallbackOnNoMatch verifies that when the first (full)
+// query finds no match and the goal has a scorer name, searchForGoalOnce
+// retries once with the scorer token dropped and uses the retry's match.
+func TestSearchForGoalOnceFallbackOnNoMatch(t *testing.T) {
+	goal := GoalInfo{
+		MatchID:    3,
+		HomeTeam:   "Wolves",
+		AwayTeam:   "West Ham",
+		HomeScore:  3,
+		AwayScore:  0,
+		ScorerName: "Mateus Mane",
+		Minute:     41,
+		MatchTime:  time.Now(),
+	}
+	fetcher := &recordingFetcher{
+		resultSets: [][]SearchResult{
+			{}, // full query (with scorer token): no results
+			{{ // relaxed retry (scorer token dropped): a match
+				Title:     "Wolves [3] - 0 West Ham - Mateus Mane 41'",
+				URL:       "https://example.com/relaxed-match",
+				PostURL:   "https://www.reddit.com/r/soccer/comments/relaxed",
+				CreatedAt: goal.MatchTime,
+			}},
+		},
+	}
+	client := NewClientWithFetcher(fetcher, &GoalLinkCache{links: make(map[string]GoalLink)})
+
+	link, err := client.searchForGoalOnce(goal)
+	if err != nil {
+		t.Fatalf("searchForGoalOnce returned err: %v", err)
+	}
+	if len(fetcher.queries) != 2 {
+		t.Fatalf("expected exactly 2 fetcher.Search calls (full + relaxed retry), got %d: %v",
+			len(fetcher.queries), fetcher.queries)
+	}
+	if want := "Wolves 3 0 West Ham Mane"; fetcher.queries[0] != want {
+		t.Errorf("first query = %q, want %q", fetcher.queries[0], want)
+	}
+	if want := "Wolves 3 0 West Ham"; fetcher.queries[1] != want {
+		t.Errorf("retry query = %q, want %q (scorer token dropped)", fetcher.queries[1], want)
+	}
+	if link == nil {
+		t.Fatal("expected a link from the relaxed retry, got nil")
+	}
+	if link.URL != "https://example.com/relaxed-match" {
+		t.Errorf("link URL = %q, want the relaxed-retry result", link.URL)
+	}
+}
+
+// TestSearchForGoalOnceNoFallbackWhenScorerAlreadyEmpty verifies that a goal
+// with no scorer name never triggers the relaxed retry: its first query is
+// already the relaxed shape (buildGoalQuery omits an empty scorer token), so
+// retrying it would be a wasted duplicate request against Reddit.
+func TestSearchForGoalOnceNoFallbackWhenScorerAlreadyEmpty(t *testing.T) {
+	goal := GoalInfo{
+		MatchID:   4,
+		HomeTeam:  "Barcelona",
+		AwayTeam:  "Real Madrid",
+		HomeScore: 1,
+		AwayScore: 1,
+		Minute:    60,
+		MatchTime: time.Now(),
+	}
+	fetcher := &recordingFetcher{} // no results at any call index
+	client := NewClientWithFetcher(fetcher, &GoalLinkCache{links: make(map[string]GoalLink)})
+
+	link, err := client.searchForGoalOnce(goal)
+	if err != nil {
+		t.Fatalf("searchForGoalOnce returned err: %v", err)
+	}
+	if link != nil {
+		t.Errorf("expected nil link (no results), got %+v", link)
+	}
+	if len(fetcher.queries) != 1 {
+		t.Fatalf("expected exactly 1 fetcher.Search call (no retry for empty-scorer goal), got %d: %v",
+			len(fetcher.queries), fetcher.queries)
 	}
 }

--- a/internal/reddit/queue.go
+++ b/internal/reddit/queue.go
@@ -45,6 +45,8 @@ type queuedWork struct {
 //   - drop-on-block semantics: a fetch that returns ErrBlocked is not cached
 //     and not re-enqueued; callers receive a nil GoalResult.Link and the
 //     queue stops fetching for CooldownPeriod
+//   - cooldown persisted to disk (when a store is configured) so a block
+//     survives process restarts
 //
 // The worker goroutine is started lazily on the first Enqueue call (via
 // sync.Once) so constructing a Client without using the async API does not
@@ -62,19 +64,22 @@ type goalQueue struct {
 	fetch fetchFunc
 	cache *GoalLinkCache
 	log   DebugLogger
+	store *queueStateStore
 }
 
 // newGoalQueue constructs a queue. interval and cooldown default to
 // QueueInterval / CooldownPeriod when zero. cache is required (callers rely
-// on the queue persisting successful results); fetch is required.
-func newGoalQueue(fetch fetchFunc, cache *GoalLinkCache, log DebugLogger, interval, cooldown time.Duration) *goalQueue {
+// on the queue persisting successful results); fetch is required. store is
+// optional — when non-nil, a cooldown already in effect from a prior process
+// is restored, and future cooldowns are persisted to it.
+func newGoalQueue(fetch fetchFunc, cache *GoalLinkCache, log DebugLogger, interval, cooldown time.Duration, store *queueStateStore) *goalQueue {
 	if interval <= 0 {
 		interval = QueueInterval
 	}
 	if cooldown <= 0 {
 		cooldown = CooldownPeriod
 	}
-	return &goalQueue{
+	q := &goalQueue{
 		keys:     make(chan GoalLinkKey, 1024),
 		interval: interval,
 		cooldown: cooldown,
@@ -82,7 +87,12 @@ func newGoalQueue(fetch fetchFunc, cache *GoalLinkCache, log DebugLogger, interv
 		fetch:    fetch,
 		cache:    cache,
 		log:      log,
+		store:    store,
 	}
+	if store != nil {
+		q.cooldownUntil = store.load().CooldownUntil
+	}
+	return q
 }
 
 // Enqueue schedules a fetch for goal. The result is delivered on reply. If a
@@ -154,7 +164,13 @@ func (q *goalQueue) run() {
 		if err != nil && errors.Is(err, ErrBlocked) {
 			q.mu.Lock()
 			q.cooldownUntil = time.Now().Add(q.cooldown)
+			until := q.cooldownUntil
 			q.mu.Unlock()
+			if q.store != nil {
+				if err := q.store.save(queueState{CooldownUntil: until}); err != nil {
+					q.debugf("queue: failed to persist cooldown state: %v", err)
+				}
+			}
 			q.debugf("queue: goal %d:%d hit ErrBlocked — cooldown for %v",
 				key.MatchID, key.Minute, q.cooldown)
 			q.complete(key, nil, false)

--- a/internal/reddit/queue.go
+++ b/internal/reddit/queue.go
@@ -3,6 +3,7 @@ package reddit
 import (
 	"errors"
 	"fmt"
+	"math/rand/v2"
 	"sync"
 	"time"
 )
@@ -16,11 +17,22 @@ const (
 	// against Reddit's edge are the failure mode this queue exists to avoid.
 	QueueInterval = 30 * time.Second
 
-	// CooldownPeriod is how long the queue pauses fetching after a single
-	// ErrBlocked response from Reddit. Long enough that an IP-level block
-	// has a chance to clear; short enough that a viewing session usually
-	// recovers within it.
+	// CooldownPeriod is the base cooldown the queue pauses fetching for after
+	// an ErrBlocked response from Reddit. Repeated blocks grow this
+	// exponentially (see nextCooldown) up to maxBackoffMultiplier, since a
+	// single fixed window isn't reliably enough to clear an IP-level block
+	// that recurs shortly after the previous cooldown elapsed.
 	CooldownPeriod = 10 * time.Minute
+
+	// maxBackoffMultiplier caps exponential backoff growth at 2^(n-1) times
+	// CooldownPeriod, i.e. 32x at n=6 (~5h20m on the 10m base) — long enough
+	// to stop hammering a persistent block, short enough that a multi-day
+	// block still gets periodically retried.
+	maxBackoffMultiplier = 6
+
+	// backoffJitterFrac is the +/- fraction of the computed backoff duration
+	// randomized in, so concurrent installs don't all retry in lockstep.
+	backoffJitterFrac = 0.2
 )
 
 // fetchFunc is the search hook the queue worker calls per goal. Injected so
@@ -40,13 +52,14 @@ type queuedWork struct {
 // enforces:
 //   - one in-flight request at a time
 //   - a minimum interval (QueueInterval) between fetches
-//   - a global cooldown (CooldownPeriod) entered on the first ErrBlocked
+//   - a global cooldown entered on ErrBlocked, growing exponentially (with
+//     jitter) on repeated blocks and resetting on the next successful fetch
 //   - in-flight de-duplication by GoalLinkKey
 //   - drop-on-block semantics: a fetch that returns ErrBlocked is not cached
 //     and not re-enqueued; callers receive a nil GoalResult.Link and the
-//     queue stops fetching for CooldownPeriod
-//   - cooldown persisted to disk (when a store is configured) so a block
-//     survives process restarts
+//     queue stops fetching for the current cooldown duration
+//   - cooldown and block-streak state persisted to disk (when a store is
+//     configured) so both survive process restarts
 //
 // The worker goroutine is started lazily on the first Enqueue call (via
 // sync.Once) so constructing a Client without using the async API does not
@@ -56,9 +69,10 @@ type goalQueue struct {
 	interval time.Duration
 	cooldown time.Duration
 
-	mu            sync.Mutex
-	items         map[GoalLinkKey]*queuedWork
-	cooldownUntil time.Time
+	mu                sync.Mutex
+	items             map[GoalLinkKey]*queuedWork
+	cooldownUntil     time.Time
+	consecutiveBlocks int
 
 	once  sync.Once
 	fetch fetchFunc
@@ -90,9 +104,26 @@ func newGoalQueue(fetch fetchFunc, cache *GoalLinkCache, log DebugLogger, interv
 		store:    store,
 	}
 	if store != nil {
-		q.cooldownUntil = store.load().CooldownUntil
+		state := store.load()
+		q.cooldownUntil = state.CooldownUntil
+		q.consecutiveBlocks = state.ConsecutiveBlocks
 	}
 	return q
+}
+
+// nextCooldown computes the next cooldown duration using exponential backoff
+// with jitter, based on how many consecutive ErrBlocked responses have been
+// seen (including this one). Must be called with q.mu held.
+func (q *goalQueue) nextCooldown() time.Duration {
+	q.consecutiveBlocks++
+	mult := min(q.consecutiveBlocks, maxBackoffMultiplier)
+	base := q.cooldown * time.Duration(1<<uint(mult-1))
+	jitter := time.Duration(float64(base) * backoffJitterFrac * (rand.Float64()*2 - 1))
+	d := base + jitter
+	if d <= 0 {
+		d = base
+	}
+	return d
 }
 
 // Enqueue schedules a fetch for goal. The result is delivered on reply. If a
@@ -163,16 +194,17 @@ func (q *goalQueue) run() {
 
 		if err != nil && errors.Is(err, ErrBlocked) {
 			q.mu.Lock()
-			q.cooldownUntil = time.Now().Add(q.cooldown)
-			until := q.cooldownUntil
+			cooldown := q.nextCooldown()
+			q.cooldownUntil = time.Now().Add(cooldown)
+			state := queueState{CooldownUntil: q.cooldownUntil, ConsecutiveBlocks: q.consecutiveBlocks}
 			q.mu.Unlock()
 			if q.store != nil {
-				if err := q.store.save(queueState{CooldownUntil: until}); err != nil {
+				if err := q.store.save(state); err != nil {
 					q.debugf("queue: failed to persist cooldown state: %v", err)
 				}
 			}
-			q.debugf("queue: goal %d:%d hit ErrBlocked — cooldown for %v",
-				key.MatchID, key.Minute, q.cooldown)
+			q.debugf("queue: goal %d:%d hit ErrBlocked (streak %d) — cooldown for %v",
+				key.MatchID, key.Minute, state.ConsecutiveBlocks, cooldown.Round(time.Second))
 			q.complete(key, nil, false)
 			continue
 		}
@@ -183,6 +215,20 @@ func (q *goalQueue) run() {
 			q.debugf("queue: goal %d:%d fetch error: %v", key.MatchID, key.Minute, err)
 			q.complete(key, nil, false)
 			continue
+		}
+
+		// Successful fetch: any prior block streak is over. Reset so the next
+		// ErrBlocked (if any) starts back at the base cooldown instead of
+		// continuing to grow from a stale streak.
+		q.mu.Lock()
+		hadStreak := q.consecutiveBlocks > 0
+		q.consecutiveBlocks = 0
+		state := queueState{CooldownUntil: q.cooldownUntil, ConsecutiveBlocks: 0}
+		q.mu.Unlock()
+		if hadStreak && q.store != nil {
+			if err := q.store.save(state); err != nil {
+				q.debugf("queue: failed to persist reset block streak: %v", err)
+			}
 		}
 
 		q.complete(key, link, true)

--- a/internal/reddit/queue_state.go
+++ b/internal/reddit/queue_state.go
@@ -1,0 +1,60 @@
+package reddit
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/0xjuanma/golazo/internal/data"
+)
+
+const queueStateFileName = "reddit_queue_state.json"
+
+// queueState is the on-disk representation of goalQueue's block state.
+type queueState struct {
+	CooldownUntil time.Time `json:"cooldown_until"`
+}
+
+// queueStateStore persists goalQueue's block state so a cooldown survives
+// process restarts. Best-effort like GoalLinkCache: load/save errors are
+// swallowed by callers, never block a fetch. Only accessed from the queue's
+// single worker goroutine (save) and once at construction (load), so no
+// internal locking is needed.
+type queueStateStore struct {
+	filePath string
+}
+
+// newQueueStateStore creates a store backed by the standard config dir.
+func newQueueStateStore() (*queueStateStore, error) {
+	dir, err := data.ConfigDir()
+	if err != nil {
+		return nil, err
+	}
+	return &queueStateStore{filePath: filepath.Join(dir, queueStateFileName)}, nil
+}
+
+// load reads the persisted state from disk. Returns a zero-value queueState
+// if the file doesn't exist or can't be parsed — mirrors GoalLinkCache.load's
+// "start empty" behavior.
+func (s *queueStateStore) load() queueState {
+	data, err := os.ReadFile(s.filePath)
+	if err != nil {
+		return queueState{}
+	}
+
+	var state queueState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return queueState{}
+	}
+	return state
+}
+
+// save persists state to disk.
+func (s *queueStateStore) save(state queueState) error {
+	data, err := json.Marshal(state)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(s.filePath, data, 0644)
+}

--- a/internal/reddit/queue_state.go
+++ b/internal/reddit/queue_state.go
@@ -13,7 +13,8 @@ const queueStateFileName = "reddit_queue_state.json"
 
 // queueState is the on-disk representation of goalQueue's block state.
 type queueState struct {
-	CooldownUntil time.Time `json:"cooldown_until"`
+	CooldownUntil     time.Time `json:"cooldown_until"`
+	ConsecutiveBlocks int       `json:"consecutive_blocks"`
 }
 
 // queueStateStore persists goalQueue's block state so a cooldown survives

--- a/internal/reddit/queue_test.go
+++ b/internal/reddit/queue_test.go
@@ -273,3 +273,110 @@ func TestQueueCooldownPersistsAcrossRestart(t *testing.T) {
 		t.Errorf("expected 0 fetch attempts on queue B (inherited cooldown), got %d", calls)
 	}
 }
+
+// waitOutCooldown blocks until q's current cooldown has elapsed, so the next
+// Enqueue reaches the fetch hook instead of being dropped by run()'s
+// cooldown check.
+func waitOutCooldown(t *testing.T, q *goalQueue) {
+	t.Helper()
+	q.mu.Lock()
+	until := q.cooldownUntil
+	q.mu.Unlock()
+	if wait := time.Until(until); wait > 0 {
+		time.Sleep(wait + 5*time.Millisecond)
+	}
+}
+
+// TestQueueBackoffGrowsOnRepeatedBlocks verifies that consecutive ErrBlocked
+// responses grow the cooldown duration exponentially (with jitter) instead
+// of reusing the same flat cooldown every time.
+func TestQueueBackoffGrowsOnRepeatedBlocks(t *testing.T) {
+	const base = 20 * time.Millisecond
+	hook := &recordingFetchHook{errors: []error{ErrBlocked, ErrBlocked, ErrBlocked}}
+	q := newGoalQueue(hook.fetch, newTestCache(t), nil, time.Millisecond, base, nil)
+
+	var deltas []time.Duration
+	for i := range 3 {
+		replies := make(chan GoalResult, 1)
+		q.Enqueue(GoalInfo{MatchID: 1, Minute: i + 1}, replies)
+		select {
+		case <-replies:
+		case <-time.After(time.Second):
+			t.Fatalf("timed out waiting for block %d", i+1)
+		}
+
+		q.mu.Lock()
+		until := q.cooldownUntil
+		streak := q.consecutiveBlocks
+		q.mu.Unlock()
+		if streak != i+1 {
+			t.Fatalf("block %d: expected consecutiveBlocks=%d, got %d", i+1, i+1, streak)
+		}
+		deltas = append(deltas, time.Until(until))
+
+		waitOutCooldown(t, q)
+	}
+
+	wantMults := []float64{1, 2, 4}
+	for i, delta := range deltas {
+		want := float64(base) * wantMults[i]
+		lo, hi := want*0.7, want*1.3 // jitter band (+/-20%) with slop for scheduling
+		if got := float64(delta); got < lo || got > hi {
+			t.Errorf("block %d cooldown delta = %v, want within [%v, %v] (base*%v)",
+				i+1, delta, time.Duration(lo), time.Duration(hi), wantMults[i])
+		}
+	}
+}
+
+// TestQueueBackoffResetsOnSuccess verifies that a successful fetch (no error,
+// found or not-found) resets the consecutive-block streak, so a later
+// ErrBlocked starts back at the base cooldown instead of continuing to grow
+// from a stale streak.
+func TestQueueBackoffResetsOnSuccess(t *testing.T) {
+	const base = 20 * time.Millisecond
+	hook := &recordingFetchHook{
+		errors:  []error{ErrBlocked, ErrBlocked, nil, ErrBlocked},
+		results: []*GoalLink{nil, nil, {MatchID: 9, Minute: 9, URL: "https://example.com/ok"}, nil},
+	}
+	q := newGoalQueue(hook.fetch, newTestCache(t), nil, time.Millisecond, base, nil)
+
+	enqueueAndWait := func(minute int) {
+		replies := make(chan GoalResult, 1)
+		q.Enqueue(GoalInfo{MatchID: 1, Minute: minute}, replies)
+		select {
+		case <-replies:
+		case <-time.After(time.Second):
+			t.Fatalf("timed out waiting for goal %d", minute)
+		}
+	}
+
+	enqueueAndWait(1) // ErrBlocked, streak=1
+	waitOutCooldown(t, q)
+	enqueueAndWait(2) // ErrBlocked, streak=2
+	waitOutCooldown(t, q)
+	enqueueAndWait(3) // success — streak should reset to 0
+
+	q.mu.Lock()
+	streak := q.consecutiveBlocks
+	q.mu.Unlock()
+	if streak != 0 {
+		t.Fatalf("expected consecutiveBlocks reset to 0 after success, got %d", streak)
+	}
+
+	enqueueAndWait(4) // ErrBlocked again — should be back at base, not 4x base
+
+	q.mu.Lock()
+	until := q.cooldownUntil
+	streakAfter := q.consecutiveBlocks
+	q.mu.Unlock()
+	if streakAfter != 1 {
+		t.Fatalf("expected consecutiveBlocks=1 after post-reset block, got %d", streakAfter)
+	}
+	delta := time.Until(until)
+	want := float64(base)
+	lo, hi := want*0.7, want*1.3
+	if got := float64(delta); got < lo || got > hi {
+		t.Errorf("post-reset cooldown delta = %v, want within [%v, %v] (base)",
+			delta, time.Duration(lo), time.Duration(hi))
+	}
+}

--- a/internal/reddit/queue_test.go
+++ b/internal/reddit/queue_test.go
@@ -66,7 +66,7 @@ func TestQueueIntervalPacing(t *testing.T) {
 			{MatchID: 1, Minute: 3, URL: "https://example.com/3"},
 		},
 	}
-	q := newGoalQueue(hook.fetch, newTestCache(t), nil, interval, time.Minute)
+	q := newGoalQueue(hook.fetch, newTestCache(t), nil, interval, time.Minute, nil)
 
 	replies := make(chan GoalResult, 3)
 	for i := 1; i <= 3; i++ {
@@ -100,7 +100,7 @@ func TestQueueCooldownOnBlocked(t *testing.T) {
 	hook := &recordingFetchHook{
 		errors: []error{ErrBlocked}, // first (and only) attempt blocked
 	}
-	q := newGoalQueue(hook.fetch, newTestCache(t), nil, time.Millisecond, time.Hour)
+	q := newGoalQueue(hook.fetch, newTestCache(t), nil, time.Millisecond, time.Hour, nil)
 
 	replies := make(chan GoalResult, 2)
 	q.Enqueue(GoalInfo{MatchID: 1, Minute: 1}, replies)
@@ -132,7 +132,7 @@ func TestQueueCooldownOnBlocked(t *testing.T) {
 func TestQueueDropsOnBlocked(t *testing.T) {
 	hook := &recordingFetchHook{errors: []error{ErrBlocked}}
 	cache := newTestCache(t)
-	q := newGoalQueue(hook.fetch, cache, nil, time.Millisecond, time.Hour)
+	q := newGoalQueue(hook.fetch, cache, nil, time.Millisecond, time.Hour, nil)
 
 	replies := make(chan GoalResult, 1)
 	key := GoalLinkKey{MatchID: 99, Minute: 33}
@@ -160,7 +160,7 @@ func TestQueueDedupesInFlight(t *testing.T) {
 		gate: gate,
 		link: &GoalLink{MatchID: 5, Minute: 10, URL: "https://example.com/dedup"},
 	}
-	q := newGoalQueue(hook.fetch, newTestCache(t), nil, time.Millisecond, time.Hour)
+	q := newGoalQueue(hook.fetch, newTestCache(t), nil, time.Millisecond, time.Hour, nil)
 
 	r1 := make(chan GoalResult, 1)
 	r2 := make(chan GoalResult, 1)
@@ -209,7 +209,7 @@ func TestQueueLazyStart(t *testing.T) {
 	hook := &recordingFetchHook{
 		results: []*GoalLink{{MatchID: 1, Minute: 1, URL: "https://example.com/lazy"}},
 	}
-	q := newGoalQueue(hook.fetch, newTestCache(t), nil, time.Millisecond, time.Hour)
+	q := newGoalQueue(hook.fetch, newTestCache(t), nil, time.Millisecond, time.Hour, nil)
 
 	// Give a hypothetical eager worker plenty of scheduler ticks to run.
 	time.Sleep(50 * time.Millisecond)
@@ -226,5 +226,50 @@ func TestQueueLazyStart(t *testing.T) {
 	}
 	if got := atomic.LoadInt32(&hook.callCount); got != 1 {
 		t.Errorf("expected 1 fetch after Enqueue, got %d", got)
+	}
+}
+
+// TestQueueCooldownPersistsAcrossRestart verifies that a cooldown entered by
+// one goalQueue is visible to a second goalQueue constructed later against
+// the same store — simulating a process restart mid-block.
+func TestQueueCooldownPersistsAcrossRestart(t *testing.T) {
+	store := &queueStateStore{filePath: filepath.Join(t.TempDir(), "reddit_queue_state.json")}
+
+	hookA := &recordingFetchHook{errors: []error{ErrBlocked}}
+	qA := newGoalQueue(hookA.fetch, newTestCache(t), nil, time.Millisecond, time.Hour, store)
+
+	repliesA := make(chan GoalResult, 1)
+	qA.Enqueue(GoalInfo{MatchID: 1, Minute: 1}, repliesA)
+	select {
+	case <-repliesA:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for blocked reply from queue A")
+	}
+
+	persisted := store.load()
+	if persisted.CooldownUntil.IsZero() || !persisted.CooldownUntil.After(time.Now()) {
+		t.Fatalf("expected persisted CooldownUntil in the future, got %v", persisted.CooldownUntil)
+	}
+
+	// Queue B simulates a fresh process reading the same store: it must
+	// inherit the cooldown and drop the goal without ever calling fetch.
+	hookB := &recordingFetchHook{
+		results: []*GoalLink{{MatchID: 2, Minute: 2, URL: "https://example.com/should-not-be-fetched"}},
+	}
+	qB := newGoalQueue(hookB.fetch, newTestCache(t), nil, time.Millisecond, time.Hour, store)
+
+	repliesB := make(chan GoalResult, 1)
+	qB.Enqueue(GoalInfo{MatchID: 2, Minute: 2}, repliesB)
+	select {
+	case r := <-repliesB:
+		if r.Link != nil {
+			t.Errorf("expected nil Link — goal should be dropped under inherited cooldown, got %+v", r.Link)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for reply from queue B")
+	}
+
+	if calls := atomic.LoadInt32(&hookB.callCount); calls != 0 {
+		t.Errorf("expected 0 fetch attempts on queue B (inherited cooldown), got %d", calls)
 	}
 }


### PR DESCRIPTION
## Summary
Hardens Reddit goal-link retrieval against IP-level blocking and adds a second chance at matching accuracy, without changing the underlying fetch strategy.

## Updates
- Persist block cooldown to disk so it survives app restarts
- Grow the cooldown exponentially with jitter on repeated blocks, resetting on the next successful fetch
- Retry a goal search once with a relaxed query when the first attempt finds no match