### PR TITLE
feat[data]: add leagues cup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Leagues Cup** - Added support for the Leagues Cup, the annual MLS vs. Liga MX club tournament, to the Americas region.
 
 ### Changed
 - Config/cache directory resolution now uses `cli-toolkit/dirs` internally instead of hand-rolled logic; no change in behavior or config location.

--- a/internal/data/settings.go
+++ b/internal/data/settings.go
@@ -95,6 +95,7 @@ var AllSupportedLeagues = map[string][]LeagueInfo{
 		{ID: 297, Name: "CONCACAF Champions Cup", Country: "North America"},
 		{ID: 298, Name: "CONCACAF Gold Cup", Country: "North America"},
 		{ID: 9821, Name: "CONCACAF Nations League", Country: "North America"},
+		{ID: 10043, Name: "Leagues Cup", Country: "North America"},
 		// South America
 		{ID: 268, Name: "Brasileirão Série A", Country: "Brazil"},
 		{ID: 8814, Name: "Brasileirão Série B", Country: "Brazil"},


### PR DESCRIPTION
## Summary

Resolves https://github.com/0xjuanma/golazo/issues/192

Adds support for the Leagues Cup (fotmob league ID 10043), the annual MLS vs. Liga MX club tournament, to the Americas region's league list.

Example:
<img width="792" height="775" alt="Screenshot 2026-09-03 at 7 01 11 PM" src="https://github.com/user-attachments/assets/29991a61-1327-4289-8430-b9b131636b49" />

