### PR TITLE
feat: add LaLiga2 to european leagues

### DIFF
--- a/docs/SUPPORTED_LEAGUES.md
+++ b/docs/SUPPORTED_LEAGUES.md
@@ -14,6 +14,7 @@ Golazo supports **65+ leagues and competitions**. Customize your selection in Se
 | 🇩🇪 | Frauen-Bundesliga |
 | 🇩🇪 | Regionalliga |
 | 🇪🇸 | La Liga |
+| 🇪🇸 | La Liga2 |
 | 🇪🇸 | Liga F |
 | 🇫🇷 | Ligue 1 |
 | 🇫🇷 | Ligue 2 |

--- a/internal/data/settings.go
+++ b/internal/data/settings.go
@@ -31,6 +31,7 @@ var AllSupportedLeagues = map[string][]LeagueInfo{
 		// Top 5 European Leagues
 		{ID: 47, Name: "Premier League", Country: "England"},
 		{ID: 87, Name: "La Liga", Country: "Spain"},
+		{ID: 140, Name: "La Liga2", Country: "Spain"},
 		{ID: 54, Name: "Bundesliga", Country: "Germany"},
 		{ID: 146, Name: "2. Bundesliga", Country: "Germany"},
 		{ID: 208, Name: "3. Liga", Country: "Germany"},


### PR DESCRIPTION
Fixes #194 
- Added LaLiga2 (ID: 140) to `AllSupportedLeagues` in `settings.go`
- Updated `SUPPORTED_LEAGUES.md` documentation
